### PR TITLE
docs: align CLAUDE.md and use-cases with ccpr workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-ccpr is a Go CLI tool that takes an AWS CodeCommit PR URL, fetches metadata/comments/diffs, and outputs AI-ready JSON for code review. It is in early MVP stage — no Go source files exist yet.
+ccpr is a local helper CLI that replaces `gh` for CodeCommit-based review workflows with Claude Code.
+
+It takes a CodeCommit PR URL, fetches metadata/comments/diffs, and outputs structured data for AI-assisted code review. This is not an official CodeCommit integration — it exists to bridge the gap between CodeCommit and AI review tools.
+
+## Intended Workflow
+
+```
+ccpr review <codecommit-pr-url>          # Summary for humans
+ccpr review <codecommit-pr-url> --json   # JSON for Claude Code / AI tools
+ccpr review <codecommit-pr-url> --patch  # Diff only
+```
+
+The primary use case: developer runs `ccpr review <url> --json`, passes the output to Claude Code, and Claude generates review comments from it. Do not search for an official Claude Code ↔ CodeCommit integration — this repository is that bridge.
 
 ## Development Rules
 
@@ -14,7 +26,7 @@ ccpr is a Go CLI tool that takes an AWS CodeCommit PR URL, fetches metadata/comm
   - docs/use-cases.md
   - docs/requirements.md
   - docs/spec.md
-    before writing implementation code
+  before writing implementation code
 
 ## MVP Scope
 
@@ -24,7 +36,7 @@ Focus only on:
 - Fetching PR metadata
 - Fetching comments
 - Generating git-based diff
-- Outputting review JSON
+- Outputting review JSON / summary / patch
 
 Out of scope (for now):
 
@@ -58,27 +70,25 @@ All commands should accept:
 - Full PR URL (preferred)
 - Optional flags for repo/region/pr-id (secondary)
 
+## AWS Profile Resolution
+
+Priority order:
+1. `--profile` flag (explicit)
+2. `profile` field in config file (`~/.config/ccpr/config.yaml`)
+3. `AWS_PROFILE` environment variable
+4. default
+
 ## Build & Development Commands
 
 ```bash
-go build ./...          # Build all packages
-go test ./... -v -race  # Run all tests with race detection
+make build              # Build binary to bin/ccpr
+make test               # Run all tests with -v -race
+make lint               # golangci-lint v2.11.4
+make vet                # go vet
+make clean              # Remove bin/
 go test ./path/to/pkg -run TestName -v  # Run a single test
-go vet ./...            # Static analysis
-```
-
-Lint is run via golangci-lint v2.11.4 (see CI config):
-
-```bash
-golangci-lint run
 ```
 
 ## CI
 
 GitHub Actions runs on push/PR to main: build, test (`-race`), vet, and golangci-lint. Go version is read from `go.mod`.
-
-## CLI Interface (planned)
-
-```bash
-ccpr review <codecommit-pr-url> --json
-```

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -4,23 +4,37 @@
 
 - Actor: Developer
 - Trigger: A CodeCommit PR URL is available
-- Precondition: AWS credentials are configured, target repository is cloned locally
+- Precondition: AWS credentials are configured, target repository is cloned locally, repo mapping configured in `~/.config/ccpr/config.yaml`
 - Main flow:
-  1. Developer gives PR URL to Claude Code
-  2. Claude runs `ccpr review <url> --json`
-  3. ccpr parses the URL to extract region, repository, and PR ID
+  1. Developer runs `ccpr review <url> --json` (directly or via Claude Code)
+  2. ccpr parses the URL to extract region, repository, and PR ID
+  3. ccpr resolves AWS profile (--profile > config > AWS_PROFILE > default)
   4. ccpr fetches PR metadata and comments via AWS SDK
-  5. ccpr generates a diff using local Git
+  5. ccpr generates a diff using local Git (merge-base strategy)
   6. ccpr outputs structured JSON combining metadata, comments, and diff
-  7. Claude uses the JSON to generate review feedback
+  7. Developer passes the JSON to Claude Code for review
+  8. Claude generates review feedback from the JSON
 - Success:
   - Developer gets AI-generated review suggestions based on complete PR context
 - Failure:
   - Invalid URL format → clear error message with expected format
   - AWS credentials missing/invalid → error with guidance
-  - Repository not found → error with repository name
+  - Repository not mapped in config → error with repository name
+- Note:
+  - ccpr is a local helper CLI, not an official CodeCommit integration
+  - Do not search for or expect an official Claude Code ↔ CodeCommit provider
 
-## UC-02 Get PR diff only
+## UC-02 Quick PR summary
+
+- Actor: Developer
+- Trigger: Developer wants a quick overview of a CodeCommit PR
+- Main flow:
+  1. Developer runs `ccpr review <url>` (no flags)
+  2. ccpr outputs a human-readable summary: title, author, status, branches, comment count, files changed
+- Success:
+  - Developer quickly understands the PR scope without opening the console
+
+## UC-03 Get PR diff only
 
 - Actor: Developer / Script
 - Trigger: Developer needs just the diff from a CodeCommit PR
@@ -31,12 +45,12 @@
 - Success:
   - Patch output is written to stdout, suitable for piping to other tools
 
-## UC-03 Review a PR with explicit parameters
+## UC-04 Review a PR with explicit parameters
 
 - Actor: Developer
 - Trigger: Developer has repo name, region, and PR ID but not the full URL
 - Main flow:
   1. Developer runs `ccpr review --repo <repo> --region <region> --pr-id <id> --json`
-  2. ccpr proceeds as in UC-01 step 4 onward
+  2. ccpr proceeds as in UC-01 step 3 onward
 - Success:
   - Same as UC-01


### PR DESCRIPTION
## Summary

- Update CLAUDE.md to clarify ccpr as a local helper CLI replacing `gh` for CodeCommit workflows
- Add intended workflow section and AWS profile resolution docs
- Update use-cases with summary output (UC-02) and workflow notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)