### PR TITLE
fix: allow flags after URL by reordering args before parsing

### DIFF
--- a/cmd/ccpr/main_test.go
+++ b/cmd/ccpr/main_test.go
@@ -49,3 +49,63 @@ func TestRunReview_InvalidURL(t *testing.T) {
 		t.Fatal("expected error for non-CodeCommit URL")
 	}
 }
+
+func TestReorderArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "flags before URL",
+			in:   []string{"-json", "https://example.com"},
+			want: []string{"-json", "https://example.com"},
+		},
+		{
+			name: "flags after URL",
+			in:   []string{"https://example.com", "--json"},
+			want: []string{"--json", "https://example.com"},
+		},
+		{
+			name: "value flag after URL",
+			in:   []string{"https://example.com", "--profile", "myprof"},
+			want: []string{"--profile", "myprof", "https://example.com"},
+		},
+		{
+			name: "mixed",
+			in:   []string{"https://example.com", "--json", "--profile", "myprof"},
+			want: []string{"--json", "--profile", "myprof", "https://example.com"},
+		},
+		{
+			name: "mutually exclusive after URL",
+			in:   []string{"https://example.com", "-json", "-patch"},
+			want: []string{"-json", "-patch", "https://example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reorderArgs(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("reorderArgs(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("reorderArgs(%v)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRunReview_FlagsAfterURL(t *testing.T) {
+	// --json after URL should still trigger mutually exclusive error with --patch
+	err := runReview([]string{"https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/repo/pull-requests/1", "-json", "-patch"})
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags after URL")
+	}
+	want := "--json and --patch are mutually exclusive"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}

--- a/cmd/ccpr/review.go
+++ b/cmd/ccpr/review.go
@@ -33,7 +33,10 @@ func runReview(args []string) error {
 	fs.StringVar(&flagConfig, "config", "", "Path to configuration file")
 	fs.StringVar(&flagProfile, "profile", "", "AWS profile name")
 
-	if err := fs.Parse(args); err != nil {
+	// Reorder args so flags come first, allowing "ccpr review <url> --json".
+	// Go's flag package stops parsing at the first non-flag argument.
+	reordered := reorderArgs(args)
+	if err := fs.Parse(reordered); err != nil {
 		return err
 	}
 
@@ -124,4 +127,43 @@ func runReview(args []string) error {
 	default:
 		return output.FormatSummary(os.Stdout, review)
 	}
+}
+
+// reorderArgs moves flags before positional args so Go's flag package
+// can parse all flags regardless of where the URL is placed.
+// Handles both "-flag value" and "-flag=value" forms.
+func reorderArgs(args []string) []string {
+	var flags, positional []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if len(a) > 0 && a[0] == '-' {
+			flags = append(flags, a)
+			// If this flag has a separate value (not bool, not =), consume next arg
+			if !isBoolFlag(a) && !containsEquals(a) && i+1 < len(args) {
+				i++
+				flags = append(flags, args[i])
+			}
+		} else {
+			positional = append(positional, a)
+		}
+	}
+	return append(flags, positional...)
+}
+
+var boolFlags = map[string]bool{
+	"-json": true, "--json": true,
+	"-patch": true, "--patch": true,
+}
+
+func isBoolFlag(s string) bool {
+	return boolFlags[s]
+}
+
+func containsEquals(s string) bool {
+	for _, c := range s {
+		if c == '=' {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- Go's `flag` package stops parsing at the first non-flag argument
- `ccpr review <url> --json` was silently ignoring `--json`, outputting summary instead
- Reorder args so flags come before positional args before parsing

## Test plan

- [x] `TestReorderArgs` — verifies arg reordering for various flag/URL combinations
- [x] `TestRunReview_FlagsAfterURL` — mutually exclusive flags detected after URL
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)