### PR TITLE
feat: add --version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+VERSION ?= $(shell git describe --tags --always --dirty)
+
 .PHONY: build test vet lint clean
 
 build:
-	go build -o bin/ccpr ./cmd/ccpr
+	go build -ldflags "-X main.version=$(VERSION)" -o bin/ccpr ./cmd/ccpr
 
 test:
 	go test ./... -v -race

--- a/cmd/ccpr/main.go
+++ b/cmd/ccpr/main.go
@@ -5,6 +5,9 @@ import (
 	"os"
 )
 
+// version is set via ldflags at build time.
+var version = "dev"
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
@@ -14,12 +17,15 @@ func main() {
 
 func run(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: ccpr <command> [flags]\n\nCommands:\n  review    Review a CodeCommit pull request")
+		return fmt.Errorf("usage: ccpr <command> [flags]\n\nCommands:\n  review     Review a CodeCommit pull request\n  --version  Print version")
 	}
 
 	switch args[0] {
 	case "review":
 		return runReview(args[1:])
+	case "--version", "version":
+		fmt.Printf("ccpr version %s\nhttps://github.com/hidetzu/ccpr/releases/tag/%s\n", version, version)
+		return nil
 	default:
 		return fmt.Errorf("unknown command: %s", args[0])
 	}

--- a/cmd/ccpr/main_test.go
+++ b/cmd/ccpr/main_test.go
@@ -4,6 +4,20 @@ import (
 	"testing"
 )
 
+func TestRun_Version(t *testing.T) {
+	err := run([]string{"--version"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestRun_VersionSubcommand(t *testing.T) {
+	err := run([]string{"version"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
 func TestRun_NoArgs(t *testing.T) {
 	err := run([]string{})
 	if err == nil {


### PR DESCRIPTION
## Summary

- Add `ccpr --version` and `ccpr version` commands (gh-style output)
- Inject version via ldflags at build time (`git describe --tags`)
- Default to "dev" when built without ldflags

## Example

```
$ ccpr --version
ccpr version v0.1.0
https://github.com/hidetzu/ccpr/releases/tag/v0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)