### PR TITLE
feat: support region field in config file

### DIFF
--- a/cmd/ccpr/list.go
+++ b/cmd/ccpr/list.go
@@ -45,9 +45,9 @@ func runList(args []string) error {
 
 	profile := cfg.ResolveProfile(flagProfile)
 
-	region := flagRegion
+	region := cfg.ResolveRegion(flagRegion)
 	if region == "" {
-		return fmt.Errorf("--region is required (or set region in config file)")
+		return fmt.Errorf("region is required: use --region flag or set region in config file")
 	}
 
 	ctx := context.Background()

--- a/cmd/ccpr/review.go
+++ b/cmd/ccpr/review.go
@@ -56,18 +56,25 @@ func runReview(args []string) error {
 		region = result.Region
 		repo = result.Repository
 		prID = result.PRId
-	} else if flagRepo != "" && flagRegion != "" && flagPRId != "" {
-		region = flagRegion
+	} else if flagRepo != "" && flagPRId != "" {
 		repo = flagRepo
 		prID = flagPRId
 	} else {
-		return fmt.Errorf("provide a PR URL or --repo, --region, and --pr-id flags")
+		return fmt.Errorf("provide a PR URL or --repo and --pr-id flags")
 	}
 
 	// Load config for repo mapping
 	cfg, err := config.Load(flagConfig)
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
+	}
+
+	// Resolve region from flag or config (URL already sets it)
+	if region == "" {
+		region = cfg.ResolveRegion(flagRegion)
+	}
+	if region == "" {
+		return fmt.Errorf("region is required: use --region flag or set region in config file")
 	}
 
 	repoPath, err := cfg.ResolveRepoPath(repo)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,17 @@ import (
 // Config holds application configuration loaded from file.
 type Config struct {
 	Profile      string            `yaml:"profile"`
+	Region       string            `yaml:"region"`
 	RepoMappings map[string]string `yaml:"repoMappings"`
+}
+
+// ResolveRegion returns the AWS region to use.
+// Priority: flagRegion > config file > "".
+func (c *Config) ResolveRegion(flagRegion string) string {
+	if flagRegion != "" {
+		return flagRegion
+	}
+	return c.Region
 }
 
 // ResolveProfile returns the AWS profile to use.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -103,6 +103,24 @@ func TestResolveRepoPath_NotMapped(t *testing.T) {
 	}
 }
 
+func TestResolveRegion(t *testing.T) {
+	cfg := &Config{Region: "ap-northeast-1"}
+
+	// Flag takes priority
+	if got := cfg.ResolveRegion("us-east-1"); got != "us-east-1" {
+		t.Errorf("flag priority: got %q, want us-east-1", got)
+	}
+	// Config fallback
+	if got := cfg.ResolveRegion(""); got != "ap-northeast-1" {
+		t.Errorf("config fallback: got %q, want ap-northeast-1", got)
+	}
+	// Empty config, empty flag
+	empty := &Config{}
+	if got := empty.ResolveRegion(""); got != "" {
+		t.Errorf("empty: got %q, want empty", got)
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {


### PR DESCRIPTION
Closes #11

## Summary

- Add `region` field to config file
- Priority: `--region` flag > config file > error
- Applied to both `review` and `list` commands
- `review` with URL still extracts region from URL (unaffected)

## Config example

```yaml
profile: your-aws-profile
region: ap-northeast-1
repoMappings:
  my-repo: /path/to/repo
```

## Test plan

- [x] `make test` — all tests pass
- [x] `TestResolveRegion` — flag priority, config fallback, empty case

🤖 Generated with [Claude Code](https://claude.com/claude-code)