### PR TITLE
feat: preserve comment thread structure with commentId and inReplyTo

### DIFF
--- a/cmd/ccpr/codecommit.go
+++ b/cmd/ccpr/codecommit.go
@@ -16,6 +16,8 @@ func convertComments(src []codecommit.Comment) []output.Comment {
 	out := make([]output.Comment, len(src))
 	for i, c := range src {
 		out[i] = output.Comment{
+			CommentId: c.CommentId,
+			InReplyTo: c.InReplyTo,
 			Author:    output.ShortAuthor(c.Author),
 			AuthorARN: c.Author,
 			Content:   c.Content,

--- a/internal/codecommit/aws_client.go
+++ b/internal/codecommit/aws_client.go
@@ -96,9 +96,11 @@ func (c *AWSClient) GetPRComments(ctx context.Context, repo, prID, beforeCommit,
 					continue
 				}
 				comment := Comment{
-					Author:   deref(c.AuthorArn),
-					Content:  deref(c.Content),
-					FilePath: filePath,
+					CommentId: deref(c.CommentId),
+					InReplyTo: deref(c.InReplyTo),
+					Author:    deref(c.AuthorArn),
+					Content:   deref(c.Content),
+					FilePath:  filePath,
 				}
 				if c.CreationDate != nil {
 					comment.Timestamp = *c.CreationDate

--- a/internal/codecommit/client.go
+++ b/internal/codecommit/client.go
@@ -21,6 +21,8 @@ type PRMetadata struct {
 // Comment represents a single comment on a pull request.
 // FilePath is empty for PR-level comments.
 type Comment struct {
+	CommentId string
+	InReplyTo string
 	Author    string
 	Content   string
 	Timestamp time.Time

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -31,6 +31,8 @@ type PRMetadata struct {
 
 // Comment is the JSON-serializable representation of a PR comment.
 type Comment struct {
+	CommentId string    `json:"commentId"`
+	InReplyTo string    `json:"inReplyTo,omitempty"`
 	Author    string    `json:"author"`
 	AuthorARN string    `json:"authorArn"`
 	Content   string    `json:"content"`

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -22,12 +22,15 @@ var testOutput = ReviewOutput{
 	},
 	Comments: []Comment{
 		{
+			CommentId: "c1",
 			Author:    "reviewer",
 			AuthorARN: "arn:aws:iam::123:user/reviewer",
 			Content:   "Looks good",
 			Timestamp: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
 		},
 		{
+			CommentId: "c2",
+			InReplyTo: "c1",
 			Author:    "reviewer",
 			AuthorARN: "arn:aws:iam::123:user/reviewer",
 			Content:   "Check this file",
@@ -59,8 +62,18 @@ func TestFormatJSON(t *testing.T) {
 		t.Errorf("comment[1].filePath = %q, want %q", parsed.Comments[1].FilePath, "src/login.go")
 	}
 
+	if parsed.Comments[0].CommentId != "c1" {
+		t.Errorf("comment[0].commentId = %q, want c1", parsed.Comments[0].CommentId)
+	}
+	if parsed.Comments[1].InReplyTo != "c1" {
+		t.Errorf("comment[1].inReplyTo = %q, want c1", parsed.Comments[1].InReplyTo)
+	}
+
 	if bytes.Contains(buf.Bytes(), []byte(`"filePath":""`)) {
 		t.Error("empty filePath should be omitted from JSON")
+	}
+	if bytes.Contains(buf.Bytes(), []byte(`"inReplyTo":""`)) {
+		t.Error("empty inReplyTo should be omitted from JSON")
 	}
 }
 


### PR DESCRIPTION
Closes #15

## Summary

- Add `commentId` and `inReplyTo` fields to comment output
- Fetch `CommentId` and `InReplyTo` from AWS SDK Comment type
- `inReplyTo` is omitted from JSON when empty (root comments)
- Summary output remains flat (thread structure is for JSON/AI consumption)

## Test plan

- [x] JSON output correctly includes `commentId` and `inReplyTo`
- [x] Empty `inReplyTo` omitted from JSON
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)