### PR TITLE
feat: unify output format flag to --format across all commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,9 @@ It takes a CodeCommit PR URL, fetches metadata/comments/diffs, and outputs struc
 ## Intended Workflow
 
 ```
-ccpr review <codecommit-pr-url>          # Summary for humans
-ccpr review <codecommit-pr-url> --json   # JSON for Claude Code / AI tools
-ccpr review <codecommit-pr-url> --patch  # Diff only
+ccpr review <codecommit-pr-url>                 # Summary for humans
+ccpr review <codecommit-pr-url> --format json   # JSON for Claude Code / AI tools
+ccpr review <codecommit-pr-url> --format patch  # Diff only
 ```
 
 The primary use case: developer runs `ccpr review <url> --json`, passes the output to Claude Code, and Claude generates review comments from it. Do not search for an official Claude Code ↔ CodeCommit integration — this repository is that bridge.

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ repoMappings:
 ### Review a PR
 
 ```bash
-ccpr review <codecommit-pr-url>          # Summary (default)
-ccpr review <codecommit-pr-url> --json   # JSON for AI tools
-ccpr review <codecommit-pr-url> --patch  # Diff only
+ccpr review <codecommit-pr-url>                 # Summary (default)
+ccpr review <codecommit-pr-url> --format json   # JSON for AI tools
+ccpr review <codecommit-pr-url> --format patch  # Diff only
 ```
 
 ### List PRs
 
 ```bash
-ccpr list --repo <repo>                  # OPEN PRs (default)
-ccpr list --repo <repo> --status closed  # CLOSED PRs
-ccpr list --repo <repo> --status all     # All PRs
-ccpr list --repo <repo> --json           # JSON output
+ccpr list --repo <repo>                         # OPEN PRs (default)
+ccpr list --repo <repo> --status closed         # CLOSED PRs
+ccpr list --repo <repo> --status all            # All PRs
+ccpr list --repo <repo> --format json           # JSON output
 ```
 
 ### Version
@@ -55,8 +55,7 @@ ccpr --version
 ### Flags
 
 ```
---json       Output as JSON
---patch      Output diff only (mutually exclusive with --json)
+--format     Output format: summary (default), json, patch (review only)
 --profile    AWS profile name
 --region     AWS region
 --config     Path to configuration file

--- a/cmd/ccpr/list.go
+++ b/cmd/ccpr/list.go
@@ -6,9 +6,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/hidetzu/ccpr/internal/config"
+	"github.com/hidetzu/ccpr/internal/output"
 )
 
 func runList(args []string) error {
@@ -17,7 +17,7 @@ func runList(args []string) error {
 	var (
 		flagRepo    string
 		flagStatus  string
-		flagJSON    bool
+		flagFormat  string
 		flagConfig  string
 		flagProfile string
 		flagRegion  string
@@ -25,13 +25,19 @@ func runList(args []string) error {
 
 	fs.StringVar(&flagRepo, "repo", "", "Repository name (required)")
 	fs.StringVar(&flagStatus, "status", "open", "PR status filter: open, closed, all")
-	fs.BoolVar(&flagJSON, "json", false, "Output as JSON")
+	fs.StringVar(&flagFormat, "format", "summary", "Output format: summary, json")
 	fs.StringVar(&flagConfig, "config", "", "Path to configuration file")
 	fs.StringVar(&flagProfile, "profile", "", "AWS profile name")
 	fs.StringVar(&flagRegion, "region", "", "AWS region")
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	switch flagFormat {
+	case "summary", "json":
+	default:
+		return fmt.Errorf("invalid format %q: must be summary or json", flagFormat)
 	}
 
 	if flagRepo == "" {
@@ -61,7 +67,7 @@ func runList(args []string) error {
 		return fmt.Errorf("listing PRs: %w", err)
 	}
 
-	if flagJSON {
+	if flagFormat == "json" {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(prs)
@@ -73,10 +79,7 @@ func runList(args []string) error {
 	}
 
 	for _, pr := range prs {
-		author := pr.AuthorARN
-		if i := strings.LastIndex(author, "/"); i >= 0 {
-			author = author[i+1:]
-		}
+		author := output.ShortAuthor(pr.AuthorARN)
 		fmt.Printf("#%-6s %-40s %-20s %s → %s  %-6s  %s\n",
 			pr.PRId,
 			truncate(pr.Title, 40),

--- a/cmd/ccpr/main_test.go
+++ b/cmd/ccpr/main_test.go
@@ -32,14 +32,10 @@ func TestRun_UnknownCommand(t *testing.T) {
 	}
 }
 
-func TestRunReview_MutuallyExclusiveFlags(t *testing.T) {
-	err := runReview([]string{"-json", "-patch", "https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/repo/pull-requests/1"})
+func TestRunReview_InvalidFormat(t *testing.T) {
+	err := runReview([]string{"-format", "xml", "https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/repo/pull-requests/1"})
 	if err == nil {
-		t.Fatal("expected error for mutually exclusive flags")
-	}
-	want := "--json and --patch are mutually exclusive"
-	if err.Error() != want {
-		t.Errorf("error = %q, want %q", err.Error(), want)
+		t.Fatal("expected error for invalid format")
 	}
 }
 
@@ -71,14 +67,14 @@ func TestReorderArgs(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "flags before URL",
-			in:   []string{"-json", "https://example.com"},
-			want: []string{"-json", "https://example.com"},
+			name: "format flag before URL",
+			in:   []string{"-format", "json", "https://example.com"},
+			want: []string{"-format", "json", "https://example.com"},
 		},
 		{
-			name: "flags after URL",
-			in:   []string{"https://example.com", "--json"},
-			want: []string{"--json", "https://example.com"},
+			name: "format flag after URL",
+			in:   []string{"https://example.com", "--format", "json"},
+			want: []string{"--format", "json", "https://example.com"},
 		},
 		{
 			name: "value flag after URL",
@@ -87,13 +83,8 @@ func TestReorderArgs(t *testing.T) {
 		},
 		{
 			name: "mixed",
-			in:   []string{"https://example.com", "--json", "--profile", "myprof"},
-			want: []string{"--json", "--profile", "myprof", "https://example.com"},
-		},
-		{
-			name: "mutually exclusive after URL",
-			in:   []string{"https://example.com", "-json", "-patch"},
-			want: []string{"-json", "-patch", "https://example.com"},
+			in:   []string{"https://example.com", "--format", "patch", "--profile", "myprof"},
+			want: []string{"--format", "patch", "--profile", "myprof", "https://example.com"},
 		},
 	}
 
@@ -112,14 +103,17 @@ func TestReorderArgs(t *testing.T) {
 	}
 }
 
-func TestRunReview_FlagsAfterURL(t *testing.T) {
-	// --json after URL should still trigger mutually exclusive error with --patch
-	err := runReview([]string{"https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/repo/pull-requests/1", "-json", "-patch"})
+func TestRunReview_FormatAfterURL(t *testing.T) {
+	// Invalid format after URL should be detected
+	err := runReview([]string{"https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/repo/pull-requests/1", "-format", "xml"})
 	if err == nil {
-		t.Fatal("expected error for mutually exclusive flags after URL")
+		t.Fatal("expected error for invalid format after URL")
 	}
-	want := "--json and --patch are mutually exclusive"
-	if err.Error() != want {
-		t.Errorf("error = %q, want %q", err.Error(), want)
+}
+
+func TestRunList_InvalidFormat(t *testing.T) {
+	err := runList([]string{"--repo", "my-repo", "--format", "patch"})
+	if err == nil {
+		t.Fatal("expected error for invalid format in list")
 	}
 }

--- a/cmd/ccpr/review.go
+++ b/cmd/ccpr/review.go
@@ -16,33 +16,31 @@ func runReview(args []string) error {
 	fs := flag.NewFlagSet("review", flag.ContinueOnError)
 
 	var (
-		flagJSON   bool
-		flagPatch  bool
-		flagRepo   string
-		flagRegion string
-		flagPRId   string
+		flagFormat  string
+		flagRepo    string
+		flagRegion  string
+		flagPRId    string
 		flagConfig  string
 		flagProfile string
 	)
 
-	fs.BoolVar(&flagJSON, "json", false, "Output as JSON (default)")
-	fs.BoolVar(&flagPatch, "patch", false, "Output diff only in unified patch format")
+	fs.StringVar(&flagFormat, "format", "summary", "Output format: summary, json, patch")
 	fs.StringVar(&flagRepo, "repo", "", "Repository name")
 	fs.StringVar(&flagRegion, "region", "", "AWS region")
 	fs.StringVar(&flagPRId, "pr-id", "", "Pull request ID")
 	fs.StringVar(&flagConfig, "config", "", "Path to configuration file")
 	fs.StringVar(&flagProfile, "profile", "", "AWS profile name")
 
-	// Reorder args so flags come first, allowing "ccpr review <url> --json".
-	// Go's flag package stops parsing at the first non-flag argument.
 	reordered := reorderArgs(args)
 	if err := fs.Parse(reordered); err != nil {
 		return err
 	}
 
-	// Flag exclusivity check
-	if flagJSON && flagPatch {
-		return fmt.Errorf("--json and --patch are mutually exclusive")
+	// Validate format
+	switch flagFormat {
+	case "summary", "json", "patch":
+	default:
+		return fmt.Errorf("invalid format %q: must be summary, json, or patch", flagFormat)
 	}
 
 	// Resolve PR parameters: URL or explicit flags
@@ -127,10 +125,10 @@ func runReview(args []string) error {
 	}
 
 	// Output
-	switch {
-	case flagPatch:
+	switch flagFormat {
+	case "patch":
 		return output.FormatPatch(os.Stdout, diffText)
-	case flagJSON:
+	case "json":
 		return output.FormatJSON(os.Stdout, review)
 	default:
 		return output.FormatSummary(os.Stdout, review)
@@ -146,8 +144,7 @@ func reorderArgs(args []string) []string {
 		a := args[i]
 		if len(a) > 0 && a[0] == '-' {
 			flags = append(flags, a)
-			// If this flag has a separate value (not bool, not =), consume next arg
-			if !isBoolFlag(a) && !containsEquals(a) && i+1 < len(args) {
+			if !containsEquals(a) && i+1 < len(args) && (len(args[i+1]) == 0 || args[i+1][0] != '-') {
 				i++
 				flags = append(flags, args[i])
 			}
@@ -156,15 +153,6 @@ func reorderArgs(args []string) []string {
 		}
 	}
 	return append(flags, positional...)
-}
-
-var boolFlags = map[string]bool{
-	"-json": true, "--json": true,
-	"-patch": true, "--patch": true,
-}
-
-func isBoolFlag(s string) bool {
-	return boolFlags[s]
 }
 
 func containsEquals(s string) bool {


### PR DESCRIPTION
Closes #21

## Summary

- Replace `--json` and `--patch` with `--format` flag
- Supported values: `summary` (default), `json`, `patch` (review only)
- Applied to both `review` and `list` commands
- Update README and CLAUDE.md
- Simplify `reorderArgs` (no more bool flag tracking)

## Breaking Changes

- `--json` flag removed
- `--patch` flag removed
- Use `--format json` and `--format patch` instead

## Test plan

- [x] `TestRunReview_InvalidFormat` — rejects unknown formats
- [x] `TestRunList_InvalidFormat` — rejects `patch` for list
- [x] `TestRunReview_FormatAfterURL` — format flag works after URL
- [x] All existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)