### PR TITLE
docs: add use cases section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ ccpr --version
 2. `--region` flag
 3. `region` in config file
 
+## Use Cases
+
+- AI-assisted code review: `ccpr review <url> --format json` → Claude Code
+- CLI-based PR browsing: `ccpr list` + `ccpr review` without opening the console
+- Quick PR access: `ccpr open <url>` to jump to the PR in browser
+
 ## Using with Claude Code
 
 For AWS CodeCommit repositories, you can use `ccpr` to provide PR data to Claude Code.


### PR DESCRIPTION
Closes #24

## Summary

- Add concise Use Cases section to README
- Three key scenarios: AI review, CLI browsing, quick browser access

🤖 Generated with [Claude Code](https://claude.com/claude-code)