### PR TITLE
feat: show thread count in summary output

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -85,8 +85,19 @@ func FormatSummary(w io.Writer, output ReviewOutput) error {
 	if _, err := fmt.Fprintf(w, "Created:  %s\n", formatDate(m.CreationDate)); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(w, "\nComments: %d\n", len(output.Comments)); err != nil {
-		return err
+	threads := countThreads(output.Comments)
+	if threads > 0 {
+		threadLabel := "threads"
+		if threads == 1 {
+			threadLabel = "thread"
+		}
+		if _, err := fmt.Fprintf(w, "\nComments: %d (%d %s)\n", len(output.Comments), threads, threadLabel); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintf(w, "\nComments: %d\n", len(output.Comments)); err != nil {
+			return err
+		}
 	}
 	if _, err := fmt.Fprintf(w, "Files:    %d changed\n", filesChanged); err != nil {
 		return err
@@ -99,6 +110,18 @@ func FormatSummary(w io.Writer, output ReviewOutput) error {
 	}
 
 	return nil
+}
+
+// countThreads counts the number of distinct comment threads.
+// A thread is a root comment (no InReplyTo).
+func countThreads(comments []Comment) int {
+	count := 0
+	for _, c := range comments {
+		if c.InReplyTo == "" {
+			count++
+		}
+	}
+	return count
 }
 
 func countChangedFiles(diff string) int {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -104,7 +104,7 @@ func TestFormatSummary(t *testing.T) {
 		"Status:   OPEN",
 		"Branch:   fix/login → main",
 		"Created:  2026-01-15 10:30",
-		"Comments: 2",
+		"Comments: 2 (1 thread)",
 		"Files:    2 changed",
 		"## Description",
 		"Fixes timeout on login",


### PR DESCRIPTION
Closes #22

## Summary

- Show thread count in summary: `Comments: 3 (2 threads)`
- Thread = root comment (no `inReplyTo`)
- Singular/plural handled: `1 thread` vs `2 threads`
- No thread info when 0 comments

## Notes

- AWS CodeCommit API does not expose resolved/unresolved status
- Thread count is the best available approximation

## Test plan

- [x] Summary output includes thread count
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)