### PR TITLE
docs: add Claude Code skill sample for PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,24 @@ ccpr --version
 
 ## Using with Claude Code
 
-For AWS CodeCommit repositories, you can use `ccpr` to provide PR data to Claude Code.
+ccpr provides a Claude Code skill for direct PR review integration.
 
-See [docs/claude-integration.md](docs/claude-integration.md) for setup instructions.
+### Quick start
+
+Copy the sample skill to your project:
+
+```bash
+mkdir -p .claude/skills/ccpr-review
+cp /path/to/ccpr/examples/claude/ccpr-review/SKILL.md .claude/skills/ccpr-review/
+```
+
+Then in Claude Code:
+
+```
+/ccpr-review <codecommit-pr-url>
+```
+
+See [docs/claude-integration.md](docs/claude-integration.md) for more options (global install, CLAUDE.md setup, customization).
 
 ## Development
 

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -47,6 +47,42 @@ User: Review this PR
 Claude: (runs ccpr review <url> --json, reads the output, provides review)
 ```
 
+## Using the skill (recommended)
+
+ccpr provides a sample Claude Code skill that wraps the review workflow into a single slash command.
+
+### Prerequisites
+
+- `ccpr` must be installed and available in your `PATH` (see [Install](../README.md#install))
+
+### Install
+
+Copy `examples/claude/ccpr-review/SKILL.md` from this repository to your project or personal skills directory:
+
+```bash
+# Project-scoped (for a specific project)
+mkdir -p .claude/skills/ccpr-review
+cp /path/to/ccpr/examples/claude/ccpr-review/SKILL.md .claude/skills/ccpr-review/
+
+# Global (available in all projects)
+mkdir -p ~/.claude/skills/ccpr-review
+cp /path/to/ccpr/examples/claude/ccpr-review/SKILL.md ~/.claude/skills/ccpr-review/
+```
+
+### Usage
+
+In Claude Code:
+
+```
+/ccpr-review <codecommit-pr-url>
+```
+
+Claude will run `ccpr review <url> --format json` and review the PR, focusing on correctness, security, performance, and readability.
+
+### Customizing the review
+
+To adjust the review focus or language, edit the copied `SKILL.md` file. The skill is plain Markdown — no code changes needed.
+
 ## Notes
 
 - ccpr is a local helper CLI, not an official AWS or Anthropic integration

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -122,6 +122,15 @@ repoMappings:
 
 ---
 
+### FR-11 Claude Code Skill
+
+- Provide a sample Claude Code skill at `examples/claude/ccpr-review/SKILL.md`
+- The skill invokes `ccpr review $ARGUMENTS --format json` and reviews the output
+- Fixed review focus: correctness, security, performance, readability
+- Users copy the skill to their `.claude/skills/` and customize as needed
+
+---
+
 ## Non-Functional Requirements
 
 ### NFR-01 CLI Behavior

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -191,6 +191,41 @@ Error codes:
 - `AWS_ERROR` — CodeCommit API failure
 - `GIT_ERROR` — local Git operation failure
 
+## Claude Code Skill (FR-11)
+
+The repository provides a Claude Code skill for direct PR review integration.
+
+### File Location
+
+```
+examples/claude/ccpr-review/SKILL.md
+```
+
+### Skill Design
+
+- **Thin wrapper**: The skill only invokes `ccpr review` and defines review behavior
+- **No ccpr-specific logic**: All data fetching and formatting is handled by the CLI
+- **Fixed review focus**: correctness, security, performance, readability
+- **User-customizable**: Users copy the skill and edit as needed
+
+### Installation
+
+Copy `examples/claude/ccpr-review/SKILL.md` to:
+- `.claude/skills/ccpr-review/SKILL.md` (project-scoped)
+- `~/.claude/skills/ccpr-review/SKILL.md` (global)
+
+### Frontmatter
+
+```yaml
+---
+name: ccpr-review
+description: Review a CodeCommit pull request using ccpr structured output
+allowed-tools: Bash(ccpr *)
+---
+```
+
+- `allowed-tools` restricts the skill to only run ccpr commands
+
 ## Dependencies
 
 - `aws-sdk-go-v2` — CodeCommit API calls

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -54,3 +54,20 @@
   2. ccpr proceeds as in UC-01 step 3 onward
 - Success:
   - Same as UC-01
+
+## UC-05 Review a PR via Claude Code skill
+
+- Actor: Developer using Claude Code
+- Trigger: A CodeCommit PR URL is available and developer wants AI review directly in Claude Code
+- Precondition: ccpr installed and configured, SKILL.md copied from `examples/claude/ccpr-review/` to user's `.claude/skills/ccpr-review/`
+- Main flow:
+  1. Developer invokes `/ccpr-review <PR_URL>` in Claude Code
+  2. The skill runs `ccpr review <PR_URL> --format json`
+  3. Claude reviews the PR output focusing on: correctness, security, performance, readability
+  4. Claude returns a structured review: summary, risks, suggested changes
+- Success:
+  - Developer gets AI-generated review without manual piping or CLAUDE.md setup
+- Note:
+  - The skill is a thin wrapper — ccpr handles data fetching, the skill defines review behavior
+  - Users can customize review focus by copying the skill to their own `.claude/skills/`
+  - Copy `examples/claude/ccpr-review/SKILL.md` to `.claude/skills/ccpr-review/` (project) or `~/.claude/skills/ccpr-review/` (global)

--- a/examples/claude/ccpr-review/SKILL.md
+++ b/examples/claude/ccpr-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: ccpr-review
+description: Review a CodeCommit pull request using ccpr structured output
+allowed-tools: Bash(ccpr *)
+---
+
+Run `ccpr review $ARGUMENTS --format json` and review the pull request based on the structured output.
+
+Focus on:
+
+- Correctness: logic errors, edge cases, missing validation
+- Security concerns: credential handling, injection risks, access control
+- Performance impact: inefficient queries, unnecessary allocations, N+1 patterns
+- Readability and maintainability: naming, structure, complexity
+
+Return your review in this format:
+
+1. **Summary** — What the PR does in 2-3 sentences
+2. **Risks** — Issues that should be addressed before merging
+3. **Suggested changes** — Specific, actionable improvements with file/line references

--- a/examples/claude/skill_test.go
+++ b/examples/claude/skill_test.go
@@ -1,0 +1,52 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSkillMD_Exists(t *testing.T) {
+	path := filepath.Join("ccpr-review", "SKILL.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("SKILL.md not found: %v", err)
+	}
+}
+
+func TestSkillMD_ValidFrontmatter(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("ccpr-review", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read SKILL.md: %v", err)
+	}
+
+	content := string(data)
+
+	// Must start with frontmatter delimiter
+	if !strings.HasPrefix(content, "---\n") {
+		t.Fatal("SKILL.md must start with ---")
+	}
+
+	// Must have closing frontmatter delimiter
+	rest := content[4:] // skip opening "---\n"
+	idx := strings.Index(rest, "\n---\n")
+	if idx < 0 {
+		t.Fatal("SKILL.md missing closing --- for frontmatter")
+	}
+
+	frontmatter := rest[:idx]
+
+	// Required fields
+	requiredFields := []string{"name:", "description:"}
+	for _, field := range requiredFields {
+		if !strings.Contains(frontmatter, field) {
+			t.Errorf("frontmatter missing required field %q", field)
+		}
+	}
+
+	// Body must not be empty
+	body := strings.TrimSpace(rest[idx+5:])
+	if body == "" {
+		t.Error("SKILL.md body is empty")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a sample Claude Code skill (`examples/claude/ccpr-review/SKILL.md`) that wraps `ccpr review --format json` into a `/ccpr-review` slash command
- Update docs (use-cases, requirements, spec, claude-integration) with FR-11 and UC-05
- Update README with quick start instructions for skill setup

## Details

Users copy the SKILL.md to their `.claude/skills/ccpr-review/` (project-scoped) or `~/.claude/skills/ccpr-review/` (global) to enable the skill. No code changes — this is documentation and a sample skill file only.

## Test plan

- [x] Verify SKILL.md is valid frontmatter + markdown
- [x] Verify docs are consistent (all paths reference `examples/claude/ccpr-review/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)