### PR TITLE
feat: add ccpr doctor command

### DIFF
--- a/cmd/ccpr/doctor.go
+++ b/cmd/ccpr/doctor.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/hidetzu/ccpr/internal/config"
+)
+
+type checkResult struct {
+	ok      bool
+	message string
+	fix     string
+}
+
+func runDoctor(args []string) error {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+
+	var (
+		flagConfig  string
+		flagProfile string
+		flagRegion  string
+	)
+
+	fs.StringVar(&flagConfig, "config", "", "Path to configuration file")
+	fs.StringVar(&flagProfile, "profile", "", "AWS profile name")
+	fs.StringVar(&flagRegion, "region", "", "AWS region")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var results []checkResult
+
+	// 1. Config file check
+	cfg, cfgResult := checkConfig(flagConfig)
+	results = append(results, cfgResult)
+
+	// 2. AWS credentials check
+	profile := ""
+	region := flagRegion
+	if cfg != nil {
+		profile = cfg.ResolveProfile(flagProfile)
+		if region == "" {
+			region = cfg.ResolveRegion("")
+		}
+	} else if flagProfile != "" {
+		profile = flagProfile
+	}
+	results = append(results, checkAWSCredentials(profile, region))
+
+	// 3. Repo mappings check (sorted for stable output)
+	if cfg != nil && len(cfg.RepoMappings) > 0 {
+		names := make([]string, 0, len(cfg.RepoMappings))
+		for name := range cfg.RepoMappings {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			results = append(results, checkRepoMapping(name, cfg.RepoMappings[name]))
+		}
+	}
+
+	// Print results
+	passed := 0
+	total := len(results)
+	for _, r := range results {
+		if r.ok {
+			fmt.Printf("✔ %s\n", r.message)
+			passed++
+		} else {
+			fmt.Printf("✖ %s\n", r.message)
+			if r.fix != "" {
+				fmt.Printf("  → %s\n", r.fix)
+			}
+		}
+	}
+
+	fmt.Printf("\n%d/%d checks passed\n", passed, total)
+
+	if passed < total {
+		return fmt.Errorf("%d check(s) failed", total-passed)
+	}
+	return nil
+}
+
+func checkConfig(flagConfig string) (*config.Config, checkResult) {
+	cfg, resolvedPath, err := config.Load(flagConfig)
+	if err != nil {
+		displayPath := resolvedPath
+		if displayPath == "" {
+			if p, e := config.DefaultPath(); e == nil {
+				displayPath = p
+			}
+		}
+		return nil, checkResult{
+			ok:      false,
+			message: fmt.Sprintf("Config file: %s", displayPath),
+			fix:     "Run: ccpr init",
+		}
+	}
+
+	return cfg, checkResult{
+		ok:      true,
+		message: fmt.Sprintf("Config file: %s", resolvedPath),
+	}
+}
+
+func checkAWSCredentials(profile, region string) checkResult {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	if profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return checkResult{
+			ok:      false,
+			message: "AWS credentials",
+			fix:     "Configure AWS credentials: aws configure",
+		}
+	}
+
+	stsClient := sts.NewFromConfig(awsCfg)
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		hint := "Configure AWS credentials: aws configure"
+		if profile != "" {
+			hint = fmt.Sprintf("Check profile %q: aws configure --profile %s", profile, profile)
+		}
+		return checkResult{
+			ok:      false,
+			message: "AWS credentials",
+			fix:     hint,
+		}
+	}
+
+	arn := ""
+	if identity.Arn != nil {
+		arn = *identity.Arn
+	}
+	return checkResult{
+		ok:      true,
+		message: fmt.Sprintf("AWS credentials: %s", arn),
+	}
+}
+
+func checkRepoMapping(name, path string) checkResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return checkResult{
+			ok:      false,
+			message: fmt.Sprintf("Repo mapping: %s → %s (path not found)", name, path),
+			fix:     "Check repoMappings in config file",
+		}
+	}
+	if !info.IsDir() {
+		return checkResult{
+			ok:      false,
+			message: fmt.Sprintf("Repo mapping: %s → %s (not a directory)", name, path),
+			fix:     "Check repoMappings in config file",
+		}
+	}
+
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
+	if err := cmd.Run(); err != nil {
+		return checkResult{
+			ok:      false,
+			message: fmt.Sprintf("Repo mapping: %s → %s (not a git repository)", name, path),
+			fix:     fmt.Sprintf("Run: git -C %s init", path),
+		}
+	}
+
+	return checkResult{
+		ok:      true,
+		message: fmt.Sprintf("Repo mapping: %s → %s (git OK)", name, path),
+	}
+}

--- a/cmd/ccpr/doctor_test.go
+++ b/cmd/ccpr/doctor_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckConfig_Valid(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("profile: test\nregion: us-east-1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, result := checkConfig(cfgPath)
+	if !result.ok {
+		t.Fatalf("expected ok, got fail: %s", result.message)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	} else if cfg.Profile != "test" {
+		t.Errorf("profile = %q, want test", cfg.Profile)
+	}
+}
+
+func TestCheckConfig_Missing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Point to a non-existent path in isolated dir
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	_ = os.Chdir(dir)
+
+	cfg, result := checkConfig("")
+	if result.ok {
+		t.Fatal("expected fail for missing config")
+	}
+	if cfg != nil {
+		t.Fatal("expected nil config")
+	}
+	if result.fix == "" {
+		t.Error("expected fix suggestion")
+	}
+}
+
+func TestCheckRepoMapping_ValidGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", dir)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	result := checkRepoMapping("test-repo", dir)
+	if !result.ok {
+		t.Fatalf("expected ok, got fail: %s", result.message)
+	}
+}
+
+func TestCheckRepoMapping_NotGitRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	result := checkRepoMapping("test-repo", dir)
+	if result.ok {
+		t.Fatal("expected fail for non-git directory")
+	}
+}
+
+func TestCheckRepoMapping_PathNotFound(t *testing.T) {
+	result := checkRepoMapping("test-repo", "/nonexistent/path/12345")
+	if result.ok {
+		t.Fatal("expected fail for missing path")
+	}
+}
+
+func TestRunDoctor_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	_ = os.Chdir(dir)
+
+	err := runDoctor([]string{})
+	if err == nil {
+		t.Fatal("expected error when config is missing")
+	}
+}

--- a/cmd/ccpr/list.go
+++ b/cmd/ccpr/list.go
@@ -44,7 +44,7 @@ func runList(args []string) error {
 		return fmt.Errorf("--repo is required for list command")
 	}
 
-	cfg, err := config.Load(flagConfig)
+	cfg, _, err := config.Load(flagConfig)
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
 	}

--- a/cmd/ccpr/main.go
+++ b/cmd/ccpr/main.go
@@ -29,7 +29,7 @@ func main() {
 
 func run(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: ccpr <command> [flags]\n\nCommands:\n  review     Review a CodeCommit pull request\n  list       List pull requests for a repository\n  open       Open a pull request in the browser\n  init       Initialize configuration file\n  --version  Print version")
+		return fmt.Errorf("usage: ccpr <command> [flags]\n\nCommands:\n  review     Review a CodeCommit pull request\n  list       List pull requests for a repository\n  open       Open a pull request in the browser\n  init       Initialize configuration file\n  doctor     Validate environment and config\n  --version  Print version")
 	}
 
 	switch args[0] {
@@ -41,6 +41,8 @@ func run(args []string) error {
 		return runOpen(args[1:])
 	case "init":
 		return runInit(args[1:])
+	case "doctor":
+		return runDoctor(args[1:])
 	case "--version", "version":
 		v := getVersion()
 		fmt.Printf("ccpr version %s\nhttps://github.com/hidetzu/ccpr/releases/tag/%s\n", v, v)

--- a/cmd/ccpr/open.go
+++ b/cmd/ccpr/open.go
@@ -49,7 +49,7 @@ func runOpen(args []string) error {
 		return fmt.Errorf("provide a PR URL or --repo and --pr-id flags")
 	}
 
-	cfg, err := config.Load(flagConfig)
+	cfg, _, err := config.Load(flagConfig)
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
 	}

--- a/cmd/ccpr/review.go
+++ b/cmd/ccpr/review.go
@@ -62,7 +62,7 @@ func runReview(args []string) error {
 	}
 
 	// Load config for repo mapping
-	cfg, err := config.Load(flagConfig)
+	cfg, _, err := config.Load(flagConfig)
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
 	}

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -143,6 +143,19 @@ repoMappings:
 
 ---
 
+### FR-13 Environment Validation (doctor)
+
+- Check config file existence and YAML validity
+- Validate AWS credentials via STS GetCallerIdentity
+- Check each repoMappings entry:
+  - Path exists on filesystem
+  - Path is a git repository
+- Print checklist with pass (✔) / fail (✖) markers
+- Suggest fix for each failure
+- Exit code 0 if all checks pass, 1 if any check fails
+
+---
+
 ## Non-Functional Requirements
 
 ### NFR-01 CLI Behavior

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -256,6 +256,37 @@ Config written to ~/.config/ccpr/config.yaml
 - `CONFIG_EXISTS` — config file already exists (exit code 1)
 - `INIT_WRITE_ERROR` — cannot create directory or write file (exit code 2)
 
+## Doctor Command (FR-13)
+
+### Behavior
+
+```
+ccpr doctor [--config <path>] [--profile <name>] [--region <region>]
+```
+
+Runs the following checks in order:
+
+1. **Config file** — exists and is valid YAML
+2. **AWS credentials** — STS GetCallerIdentity succeeds
+3. **Repo mappings** — each path exists and is a git repository
+
+### Output
+
+```
+✔ Config file: ~/.config/ccpr/config.yaml
+✔ AWS credentials: arn:aws:iam::123456789012:user/example-user
+✔ Repo mapping: my-repo → /home/user/src/my-repo (git OK)
+✖ Repo mapping: other-repo → /tmp/missing (path not found)
+  → Check repoMappings in ~/.config/ccpr/config.yaml
+
+3/4 checks passed
+```
+
+### Exit Codes
+
+- `0` — all checks passed
+- `1` — one or more checks failed
+
 ## Dependencies
 
 - `aws-sdk-go-v2` — CodeCommit API calls

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -75,7 +75,23 @@
   - Config file already exists → error with message (use `--force` to overwrite)
   - Cannot create config directory → error with path
 
-## UC-06 Review a PR via Claude Code skill
+## UC-06 Validate environment and config
+
+- Actor: Developer
+- Trigger: Developer wants to verify ccpr setup is working correctly
+- Precondition: ccpr is installed
+- Main flow:
+  1. Developer runs `ccpr doctor`
+  2. ccpr checks config file existence and validity
+  3. ccpr validates AWS credentials via STS GetCallerIdentity
+  4. ccpr checks each repoMappings entry (path exists, is a git repo)
+  5. ccpr prints a checklist of results with pass/fail markers
+- Success:
+  - All checks pass — developer is confident the setup works
+- Failure:
+  - Each failed check includes a suggestion for how to fix it
+
+## UC-07 Review a PR via Claude Code skill
 
 - Actor: Developer using Claude Code
 - Trigger: A CodeCommit PR URL is available and developer wants AI review directly in Claude Code

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,14 +39,16 @@ func (c *Config) ResolveProfile(flagProfile string) string {
 	return ""
 }
 
-// Load searches for a configuration file and returns the parsed Config.
+// Load searches for a configuration file and returns the parsed Config
+// along with the resolved file path.
 // Search order:
 //  1. explicit path (if non-empty)
 //  2. .ccpr.yaml in current directory
 //  3. ~/.config/ccpr/config.yaml
-func Load(path string) (*Config, error) {
+func Load(path string) (*Config, string, error) {
 	if path != "" {
-		return loadFrom(path)
+		cfg, err := loadFrom(path)
+		return cfg, path, err
 	}
 
 	candidates := []string{".ccpr.yaml"}
@@ -56,11 +58,12 @@ func Load(path string) (*Config, error) {
 
 	for _, c := range candidates {
 		if _, err := os.Stat(c); err == nil {
-			return loadFrom(c)
+			cfg, err := loadFrom(c)
+			return cfg, c, err
 		}
 	}
 
-	return nil, fmt.Errorf("config file not found (searched .ccpr.yaml and ~/.config/ccpr/config.yaml)")
+	return nil, "", fmt.Errorf("config file not found (searched .ccpr.yaml and ~/.config/ccpr/config.yaml)")
 }
 
 // ResolveRepoPath returns the local filesystem path for a CodeCommit repository name.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,7 @@ func TestLoad_ExplicitPath(t *testing.T) {
   other: /tmp/other
 `)
 
-	cfg, err := Load(cfgPath)
+	cfg, _, err := Load(cfgPath)
 	if err != nil {
 		t.Fatalf("Load(%q) unexpected error: %v", cfgPath, err)
 	}
@@ -38,7 +38,7 @@ func TestLoad_DotCcprYaml(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg, err := Load("")
+	cfg, _, err := Load("")
 	if err != nil {
 		t.Fatalf("Load(\"\") unexpected error: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestLoad_FileNotFound(t *testing.T) {
 	// Override home to empty dir so ~/.config/ccpr/config.yaml also doesn't exist
 	t.Setenv("HOME", dir)
 
-	_, err := Load("")
+	_, _, err := Load("")
 	if err == nil {
 		t.Fatal("Load(\"\") expected error for missing config, got nil")
 	}
@@ -70,9 +70,40 @@ func TestLoad_InvalidYAML(t *testing.T) {
 	cfgPath := filepath.Join(dir, "bad.yaml")
 	writeFile(t, cfgPath, `[[[invalid`)
 
-	_, err := Load(cfgPath)
+	_, _, err := Load(cfgPath)
 	if err == nil {
 		t.Fatal("Load() expected error for invalid YAML, got nil")
+	}
+}
+
+func TestLoad_ResolvedPathMatchesActualFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create both .ccpr.yaml and ~/.config/ccpr/config.yaml
+	dotCcpr := filepath.Join(dir, ".ccpr.yaml")
+	writeFile(t, dotCcpr, "profile: local\n")
+
+	defaultDir := filepath.Join(dir, ".config", "ccpr")
+	if err := os.MkdirAll(defaultDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(defaultDir, "config.yaml"), "profile: global\n")
+
+	t.Setenv("HOME", dir)
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	_ = os.Chdir(dir)
+
+	// Load("") should pick .ccpr.yaml and report that path
+	cfg, resolvedPath, err := Load("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Profile != "local" {
+		t.Errorf("profile = %q, want local", cfg.Profile)
+	}
+	if resolvedPath != ".ccpr.yaml" {
+		t.Errorf("resolvedPath = %q, want .ccpr.yaml", resolvedPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `ccpr doctor` command to validate environment and config
- Checks: config file existence/validity, AWS credentials (STS GetCallerIdentity), repoMappings (path exists, is git repo)
- Each failed check includes an actionable fix suggestion
- Exit code 0 if all pass, 1 if any fail

Closes #32

## Example Output

```
✔ Config file: ~/.config/ccpr/config.yaml
✔ AWS credentials: arn:aws:iam::123456789012:user/example-user
✔ Repo mapping: my-repo → /home/user/src/my-repo (git OK)
✖ Repo mapping: other-repo → /tmp/missing (path not found)
  → Check repoMappings in config file

3/4 checks passed
```

## Test plan

- [x] Valid config → ✔
- [x] Missing config → ✖ with `ccpr init` suggestion
- [x] Valid git repo mapping → ✔
- [x] Non-git directory → ✖
- [x] Missing path → ✖
- [x] AWS credentials failure → ✖ with fix hint
- [x] All unit tests pass (`make test`)
- [x] Lint clean (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)