### PR TITLE
chore: add PR template and Type-of-change CI check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+-
+-
+
+## Type of change
+
+- [ ] Bug fix (`fix:`)
+- [ ] New feature (`feat:`)
+- [ ] Breaking change
+- [ ] Documentation (`docs:`)
+- [ ] Refactor / chore (`refactor:` / `chore:`)
+- [ ] Test (`test:`)
+
+## Test plan
+
+- [ ] `make build` / `make test` / `make lint` all pass
+- [ ] All command examples and flag names match current implementation
+
+## Spec-driven checklist
+
+- [ ] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code (or N/A for non-feature changes)
+- [ ] No breaking changes to JSON output (see `docs/versioning.md`); if golden tests in `cmd/ccpr/testdata/` changed, called out below
+
+## Related issues
+
+Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,27 @@ jobs:
       - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
+
+  pr-template:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check 'Type of change' is selected
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_BODY:-}" ]; then
+            echo "::error::PR body is empty. Please fill out the PR template."
+            exit 1
+          fi
+          section=$(printf '%s\n' "$PR_BODY" | awk '
+            /^## Type of change/ { in_section=1; next }
+            /^## / && in_section { in_section=0 }
+            in_section { print }
+          ')
+          if ! printf '%s\n' "$section" | grep -qE '^[[:space:]]*- \[[xX]\]'; then
+            echo "::error::Please check at least one item under '## Type of change' in the PR description."
+            exit 1
+          fi
+          echo "OK: Type of change has at least one selection."


### PR DESCRIPTION
## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` mirroring the recent Summary + Test plan PR style, with project-specific Spec-driven checklist (docs先行 / JSON contract reminders)
- Add `pr-template` job to `ci.yml` that requires at least one `## Type of change` checkbox to be selected on every PR (skipped on push to main)

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [ ] Documentation (`docs:`)
- [x] Refactor / chore (`refactor:` / `chore:`)
- [ ] Test (`test:`)

## Test plan

- [x] No Go code changes — `make build` / `make test` / `make lint` unaffected; CI will verify
- [x] New `pr-template` CI job runs on this PR itself and validates the "Type of change" rule end-to-end (this PR has `Refactor / chore` checked, so it should pass)
- [x] Verified `if: github.event_name == 'pull_request'` so the job is skipped on push to main

## Spec-driven checklist

- [x] N/A — this is repo process tooling, not a ccpr feature, so `docs/use-cases.md` / `docs/requirements.md` / `docs/spec.md` are unaffected
- [x] No breaking changes to JSON output; no changes to `cmd/ccpr/testdata/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)