### PR TITLE
fix: require region for create and comment

### DIFF
--- a/cmd/ccpr/comment.go
+++ b/cmd/ccpr/comment.go
@@ -81,6 +81,9 @@ func runComment(args []string) error {
 	if region == "" {
 		region = cfg.ResolveRegion(flagRegion)
 	}
+	if region == "" {
+		return fmt.Errorf("region is required: use --region flag or set region in config file")
+	}
 	profile := cfg.ResolveProfile(flagProfile)
 
 	// Get PR metadata for commit IDs

--- a/cmd/ccpr/comment_test.go
+++ b/cmd/ccpr/comment_test.go
@@ -86,6 +86,22 @@ func TestRunComment_PartialFlags(t *testing.T) {
 	}
 }
 
+func TestRunComment_MissingRegion(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("repoMappings:\n  my-repo: .\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runComment([]string{"--config", cfgPath, "--repo", "my-repo", "--pr-id", "123", "--body", "test"})
+	if err == nil {
+		t.Fatal("expected error for missing region")
+	}
+	if !strings.Contains(err.Error(), "region is required") {
+		t.Errorf("error should mention region: %v", err)
+	}
+}
+
 func TestPrintCommentSummary(t *testing.T) {
 	var buf bytes.Buffer
 	err := printCommentSummary(&buf, "123", "abc-def", "user1", "2026-03-31T17:00:00+09:00")

--- a/cmd/ccpr/create.go
+++ b/cmd/ccpr/create.go
@@ -76,6 +76,9 @@ func runCreate(args []string) error {
 	}
 
 	region := cfg.ResolveRegion(flagRegion)
+	if region == "" {
+		return fmt.Errorf("region is required: use --region flag or set region in config file")
+	}
 	profile := cfg.ResolveProfile(flagProfile)
 
 	// Resolve source branch

--- a/cmd/ccpr/create_test.go
+++ b/cmd/ccpr/create_test.go
@@ -101,6 +101,22 @@ func TestRunCreate_InvalidFormat(t *testing.T) {
 	}
 }
 
+func TestRunCreate_MissingRegion(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("repoMappings:\n  my-repo: .\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runCreate([]string{"--config", cfgPath, "--repo", "my-repo", "--title", "test", "--dest", "main", "--source", "feature"})
+	if err == nil {
+		t.Fatal("expected error for missing region")
+	}
+	if !strings.Contains(err.Error(), "region is required") {
+		t.Errorf("error should mention region: %v", err)
+	}
+}
+
 func TestBuildConsoleURL(t *testing.T) {
 	url := buildConsoleURL("ap-northeast-1", "my-repo", "42")
 	want := "https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/pull-requests/42"


### PR DESCRIPTION
## Summary

- Require an explicit or configured AWS region for `ccpr create`
- Require an explicit, URL-derived, or configured AWS region for `ccpr comment`
- Add regression tests for missing-region handling in both commands

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [ ] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:` / `chore:`)
- [x] Test (`test:`)

## Test plan

- [x] `make build` / `make test` / `make lint` all pass
- [x] All command examples and flag names match current implementation

## Spec-driven checklist

- [x] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code (or N/A for non-feature changes)
- [x] No breaking changes to JSON output (see `docs/versioning.md`); if golden tests in `cmd/ccpr/testdata/` changed, called out below

## Related issues

N/A
