### PR TITLE
fix: expand home in repo mappings

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -91,11 +91,15 @@ Constraints:
 
 - Map repository name to local filesystem path
 - Configuration file defines mapping
+- Path values support `~` and `~/` as a prefix for the user's home directory
+  - `~/src/repo` → `/home/<user>/src/repo` (expanded at config load time)
+  - `~user/foo` form is **not** supported (returned as-is)
 
 Example:
 
 repoMappings:
   my-repo: /work/src/my-repo
+  another-repo: ~/src/another-repo
 
 - Return error if mapping is missing
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -93,8 +93,14 @@ Example `.ccpr.yaml`:
 ```yaml
 repoMappings:
   my-repo: /work/src/my-repo
-  another-repo: /home/user/projects/another-repo
+  another-repo: ~/projects/another-repo
 ```
+
+### Path Expansion
+
+`repoMappings` values support a leading `~` or `~/` which is expanded to the
+current user's home directory at config load time. Other forms such as
+`~otheruser/foo` are returned unchanged.
 
 ### Output
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -125,5 +126,31 @@ func loadFrom(path string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing config %s: %w", path, err)
 	}
+
+	for name, p := range cfg.RepoMappings {
+		expanded, err := expandHome(p)
+		if err != nil {
+			return nil, fmt.Errorf("expanding repoMappings[%q]: %w", name, err)
+		}
+		cfg.RepoMappings[name] = expanded
+	}
+
 	return &cfg, nil
+}
+
+// expandHome expands a leading "~" or "~/" in path to the user's home directory.
+// Returns the path unchanged for other forms (e.g., "~user/foo", absolute paths,
+// relative paths).
+func expandHome(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, path[2:]), nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -152,6 +152,40 @@ func TestResolveRegion(t *testing.T) {
 	}
 }
 
+func TestLoad_ExpandsHomeInRepoMappings(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	// Note: bare `~` is YAML null, so the literal "~" string must be quoted.
+	writeFile(t, cfgPath, `repoMappings:
+  with-tilde-slash: ~/src/repo
+  bare-tilde: '~'
+  absolute: /work/src/abs
+  relative: rel/path
+  other-user: ~someone/else
+`)
+
+	cfg, _, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%q) unexpected error: %v", cfgPath, err)
+	}
+
+	cases := map[string]string{
+		"with-tilde-slash": filepath.Join(home, "src/repo"),
+		"bare-tilde":       home,
+		"absolute":         "/work/src/abs",
+		"relative":         "rel/path",
+		"other-user":       "~someone/else",
+	}
+	for name, want := range cases {
+		if got := cfg.RepoMappings[name]; got != want {
+			t.Errorf("%s: got %q, want %q", name, got, want)
+		}
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {


### PR DESCRIPTION
## Summary

- Expand `~` and `~/...` prefixes in `repoMappings` to the current user's home directory
- Leave unsupported forms such as `~otheruser/path` unchanged
- Document the supported path expansion behavior in requirements and spec docs

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [x] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:` / `chore:`)
- [x] Test (`test:`)

## Test plan

- [x] `make build` / `make test` / `make lint` all pass
- [x] All command examples and flag names match current implementation

Validated with:

- `GOCACHE=/tmp/ccpr-gocache GOMODCACHE=/tmp/ccpr-gomodcache go test ./internal/config`
- `GOCACHE=/tmp/ccpr-gocache GOMODCACHE=/tmp/ccpr-gomodcache go test ./...`
- `GOCACHE=/tmp/ccpr-gocache GOMODCACHE=/tmp/ccpr-gomodcache go vet ./...`
- `GOCACHE=/tmp/ccpr-gocache GOMODCACHE=/tmp/ccpr-gomodcache go build ./...`

## Spec-driven checklist

- [x] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code (or N/A for non-feature changes)
- [x] No breaking changes to JSON output (see `docs/versioning.md`); if golden tests in `cmd/ccpr/testdata/` changed, called out below

## Related issues

N/A