### PR TITLE
fix: resolve region from AWS env vars

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -216,7 +216,7 @@ repoMappings:
 
 **AWS プロファイル解決順序:** `--profile` フラグ > 設定ファイル > `AWS_PROFILE` 環境変数 > デフォルト
 
-**AWS リージョン解決順序:** PR URL（自動検出）> `--region` フラグ > 設定ファイル
+**AWS リージョン解決順序:** PR URL（自動検出）> `--region` フラグ > 設定ファイル > `AWS_REGION` 環境変数 > `AWS_DEFAULT_REGION` 環境変数
 
 ---
 
@@ -226,7 +226,7 @@ repoMappings:
 - AWS認証確認: `aws sts get-caller-identity --profile your-aws-profile`
 - SSOの場合: `aws sso login --profile your-aws-profile`
 - `no local path mapping` → `config.yaml` の `repoMappings` を追加
-- `region is required` → `--region` フラグか設定ファイルで指定
+- `region is required` → `--region` フラグ、設定ファイル、または `AWS_REGION` / `AWS_DEFAULT_REGION` 環境変数で指定
 - diff が空 → `git fetch origin` を実行してから再試行
 
 ---

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ repoMappings:
 
 **AWS Profile Resolution:** `--profile` flag > config file > `AWS_PROFILE` env > default
 
-**AWS Region Resolution:** PR URL (auto) > `--region` flag > config file
+**AWS Region Resolution:** PR URL (auto) > `--region` flag > config file > `AWS_REGION` env > `AWS_DEFAULT_REGION` env
 
 ---
 
@@ -227,7 +227,7 @@ repoMappings:
 - Check AWS credentials: `aws sts get-caller-identity --profile your-aws-profile`
 - Using SSO? Run `aws sso login --profile your-aws-profile` first
 - `no local path mapping` → add repo to `repoMappings` in config.yaml
-- `region is required` → set via `--region` flag or config file
+- `region is required` → set via `--region` flag, config file, or `AWS_REGION` / `AWS_DEFAULT_REGION` env
 - Empty diff → run `git fetch origin` and retry
 
 ---

--- a/cmd/ccpr/comment.go
+++ b/cmd/ccpr/comment.go
@@ -82,7 +82,7 @@ func runComment(args []string) error {
 		region = cfg.ResolveRegion(flagRegion)
 	}
 	if region == "" {
-		return fmt.Errorf("region is required: use --region flag or set region in config file")
+		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
 	}
 	profile := cfg.ResolveProfile(flagProfile)
 

--- a/cmd/ccpr/create.go
+++ b/cmd/ccpr/create.go
@@ -77,7 +77,7 @@ func runCreate(args []string) error {
 
 	region := cfg.ResolveRegion(flagRegion)
 	if region == "" {
-		return fmt.Errorf("region is required: use --region flag or set region in config file")
+		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
 	}
 	profile := cfg.ResolveProfile(flagProfile)
 

--- a/cmd/ccpr/list.go
+++ b/cmd/ccpr/list.go
@@ -53,7 +53,7 @@ func runList(args []string) error {
 
 	region := cfg.ResolveRegion(flagRegion)
 	if region == "" {
-		return fmt.Errorf("region is required: use --region flag or set region in config file")
+		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
 	}
 
 	ctx := context.Background()

--- a/cmd/ccpr/open.go
+++ b/cmd/ccpr/open.go
@@ -58,7 +58,7 @@ func runOpen(args []string) error {
 		region = cfg.ResolveRegion(flagRegion)
 	}
 	if region == "" {
-		return fmt.Errorf("region is required: use --region flag or set region in config file")
+		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
 	}
 
 	openURL := buildConsoleURL(region, repo, prID)

--- a/cmd/ccpr/review.go
+++ b/cmd/ccpr/review.go
@@ -72,7 +72,7 @@ func runReview(args []string) error {
 		region = cfg.ResolveRegion(flagRegion)
 	}
 	if region == "" {
-		return fmt.Errorf("region is required: use --region flag or set region in config file")
+		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
 	}
 
 	repoPath, err := cfg.ResolveRepoPath(repo)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -180,7 +180,7 @@ repoMappings:
 - Open a CodeCommit PR in the default browser
 - Resolve PR parameters from URL or `--repo` + `--pr-id` flags
 - Build CodeCommit console URL from region, repository, and PR ID
-- Region is required (from URL, `--region` flag, or config)
+- Region is required (from URL, or resolved per FR-17)
 - Fall back to printing URL to stdout if browser cannot be opened
 
 ---
@@ -198,7 +198,19 @@ repoMappings:
 - `--description` and `--description-file` are mutually exclusive
 - Summary output (default): PR ID, title, source/destination branches, console URL
 - JSON output (`--format json`): machine-readable result for piping to other commands
-- Follow AWS profile/region resolution priority (FR-09)
+- Follow AWS profile resolution priority (FR-09) and region resolution priority (FR-17)
+
+---
+
+### FR-17 AWS Region Resolution
+
+- Resolve AWS region in the following order:
+  1. `--region` flag (explicit)
+  2. `region` field in config file
+  3. `AWS_REGION` environment variable
+  4. `AWS_DEFAULT_REGION` environment variable
+  5. empty (commands that require a region will error with guidance)
+- The env-variable fallbacks match the AWS SDK convention so users with `AWS_REGION` already set in their shell do not need to duplicate it in `~/.config/ccpr/config.yaml`
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -302,7 +302,7 @@ ccpr open --repo <repo> --pr-id <id> --region <region>
 
 ### Error Cases
 
-- `MISSING_REGION` — region not provided and not in config (exit code 1)
+- `MISSING_REGION` — region could not be resolved from URL, `--region`, config, `AWS_REGION`, or `AWS_DEFAULT_REGION` (exit code 1)
 - `INVALID_URL` — malformed PR URL (exit code 1)
 
 ## Comment Command (FR-14)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,12 +17,21 @@ type Config struct {
 }
 
 // ResolveRegion returns the AWS region to use.
-// Priority: flagRegion > config file > "".
+// Priority: flagRegion > config file > AWS_REGION env > AWS_DEFAULT_REGION env > "".
 func (c *Config) ResolveRegion(flagRegion string) string {
 	if flagRegion != "" {
 		return flagRegion
 	}
-	return c.Region
+	if c.Region != "" {
+		return c.Region
+	}
+	if env := os.Getenv("AWS_REGION"); env != "" {
+		return env
+	}
+	if env := os.Getenv("AWS_DEFAULT_REGION"); env != "" {
+		return env
+	}
+	return ""
 }
 
 // ResolveProfile returns the AWS profile to use.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,6 +135,10 @@ func TestResolveRepoPath_NotMapped(t *testing.T) {
 }
 
 func TestResolveRegion(t *testing.T) {
+	// Isolate from any AWS_* env present in the test runner's environment.
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+
 	cfg := &Config{Region: "ap-northeast-1"}
 
 	// Flag takes priority
@@ -145,10 +149,47 @@ func TestResolveRegion(t *testing.T) {
 	if got := cfg.ResolveRegion(""); got != "ap-northeast-1" {
 		t.Errorf("config fallback: got %q, want ap-northeast-1", got)
 	}
-	// Empty config, empty flag
+	// Empty config, empty flag, no env
 	empty := &Config{}
 	if got := empty.ResolveRegion(""); got != "" {
 		t.Errorf("empty: got %q, want empty", got)
+	}
+}
+
+func TestResolveRegion_EnvFallback(t *testing.T) {
+	cfg := &Config{}
+
+	// AWS_REGION fallback when no flag and no config
+	t.Setenv("AWS_REGION", "us-west-2")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	if got := cfg.ResolveRegion(""); got != "us-west-2" {
+		t.Errorf("AWS_REGION: got %q, want us-west-2", got)
+	}
+
+	// AWS_DEFAULT_REGION fallback when AWS_REGION not set
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "eu-central-1")
+	if got := cfg.ResolveRegion(""); got != "eu-central-1" {
+		t.Errorf("AWS_DEFAULT_REGION: got %q, want eu-central-1", got)
+	}
+
+	// AWS_REGION takes priority over AWS_DEFAULT_REGION
+	t.Setenv("AWS_REGION", "us-west-2")
+	t.Setenv("AWS_DEFAULT_REGION", "eu-central-1")
+	if got := cfg.ResolveRegion(""); got != "us-west-2" {
+		t.Errorf("AWS_REGION over AWS_DEFAULT_REGION: got %q, want us-west-2", got)
+	}
+
+	// Config takes priority over env
+	cfgWithRegion := &Config{Region: "ap-northeast-1"}
+	t.Setenv("AWS_REGION", "us-west-2")
+	if got := cfgWithRegion.ResolveRegion(""); got != "ap-northeast-1" {
+		t.Errorf("config over env: got %q, want ap-northeast-1", got)
+	}
+
+	// Flag takes priority over everything
+	if got := cfgWithRegion.ResolveRegion("eu-west-1"); got != "eu-west-1" {
+		t.Errorf("flag over all: got %q, want eu-west-1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Resolve AWS region from `AWS_REGION` and `AWS_DEFAULT_REGION` when no `--region` flag or config region is set
- Update command error messages and README troubleshooting to mention the supported region environment variables
- Document the region resolution priority in requirements and spec docs

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [x] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:` / `chore:`)
- [x] Test (`test:`)

## Test plan

- [x] `make build` / `make test` / `make lint` all pass
- [x] All command examples and flag names match current implementation

Validated with:

- `GOCACHE=/tmp/ccpr-gocache GOMODCACHE=/tmp/ccpr-gomodcache go test ./...`
- `GOCACHE=/tmp/ccpr-gocache GOMODCACHE=/tmp/ccpr-gomodcache go vet ./...`
- `GOCACHE=/tmp/ccpr-gocache GOMODCACHE=/tmp/ccpr-gomodcache go build ./...`
- `git diff --check`

## Spec-driven checklist

- [x] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code (or N/A for non-feature changes)
- [x] No breaking changes to JSON output (see `docs/versioning.md`); if golden tests in `cmd/ccpr/testdata/` changed, called out below

## Related issues

N/A
