### PR TITLE
fix: wrap ccpr_list MCP output in object schema

### DIFF
--- a/cmd/ccpr-mcp/main.go
+++ b/cmd/ccpr-mcp/main.go
@@ -19,7 +19,18 @@ type listInput struct {
 	Region  string `json:"region,omitempty" jsonschema:"AWS region"`
 }
 
+type listOutput struct {
+	PullRequests []app.ListPullRequest `json:"pullRequests" jsonschema:"PR summaries for the repository"`
+}
+
 func main() {
+	server := newServer()
+	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func newServer() *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "ccpr-mcp",
 		Version: version,
@@ -30,12 +41,10 @@ func main() {
 		Description: "List AWS CodeCommit pull requests for a repository.",
 	}, listPullRequests)
 
-	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
-		log.Fatal(err)
-	}
+	return server
 }
 
-func listPullRequests(ctx context.Context, _ *mcp.CallToolRequest, input listInput) (*mcp.CallToolResult, []app.ListPullRequest, error) {
+func listPullRequests(ctx context.Context, _ *mcp.CallToolRequest, input listInput) (*mcp.CallToolResult, listOutput, error) {
 	prs, err := app.ListPullRequests(ctx, app.ListPullRequestsOptions{
 		Repo:    input.Repo,
 		Status:  input.Status,
@@ -44,9 +53,9 @@ func listPullRequests(ctx context.Context, _ *mcp.CallToolRequest, input listInp
 		Region:  input.Region,
 	}, newCodeCommitClient)
 	if err != nil {
-		return nil, nil, err
+		return nil, listOutput{}, err
 	}
-	return nil, prs, nil
+	return nil, listOutput{PullRequests: prs}, nil
 }
 
 func newCodeCommitClient(ctx context.Context, region, profile string) (codecommit.Client, error) {

--- a/cmd/ccpr-mcp/main_test.go
+++ b/cmd/ccpr-mcp/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func TestNewServerRegistersTools(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("newServer() panicked: %v", r)
+		}
+	}()
+
+	if got := newServer(); got == nil {
+		t.Fatal("newServer() returned nil")
+	}
+}

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -92,7 +92,7 @@ Array of PR summary objects.
 
 Empty result: `[]`
 
-The MCP tool `ccpr_list` returns the same PR summary object array.
+The MCP tool `ccpr_list` wraps the same PR summary objects in an enclosing object under `pullRequests` (MCP tool output schemas must be objects).
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -219,20 +219,22 @@ Input schema:
 Output schema:
 
 ```json
-[
-  {
-    "prId": "42",
-    "title": "Add feature X",
-    "authorArn": "arn:aws:iam::123456789012:user/example",
-    "sourceBranch": "feature/x",
-    "destinationBranch": "main",
-    "status": "OPEN",
-    "creationDate": "2026-04-01T10:00:00Z"
-  }
-]
+{
+  "pullRequests": [
+    {
+      "prId": "42",
+      "title": "Add feature X",
+      "authorArn": "arn:aws:iam::123456789012:user/example",
+      "sourceBranch": "feature/x",
+      "destinationBranch": "main",
+      "status": "OPEN",
+      "creationDate": "2026-04-01T10:00:00Z"
+    }
+  ]
+}
 ```
 
-The output is the same schema as `ccpr list --format json`; consumers must ignore unknown fields for forward compatibility.
+The MCP tool wraps the PR summary array in an object under `pullRequests` because MCP tool output schemas must be objects. Each element of `pullRequests` uses the same field names and types as `ccpr list --format json`. Consumers must ignore unknown fields for forward compatibility.
 
 ### Error Handling
 


### PR DESCRIPTION
## Summary

- `ccpr-mcp` panicked on startup with `AddTool "ccpr_list": output schema must have type "object"` because the tool returned a slice and the MCP go-sdk requires object-typed output schemas.
- Wrap the PR summary array in an object under `pullRequests` and update `docs/spec.md` and `docs/json-schema.md` to reflect the new tool output shape.
- Extract `newServer()` from `main()` and add a smoke test that constructs the server, so future tool schema mismatches surface in CI rather than at runtime.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [x] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:` / `chore:`)
- [x] Test (`test:`)

(Primary type: `fix:`. Doc and test changes are part of the same fix.)

## Test plan

- [x] `make build` / `make build-mcp` / `make test` / `make vet` / `make lint` all pass
- [x] `go test ./cmd/ccpr-mcp/...` covers `newServer()` (would have caught the original panic)
- [x] Manual JSON-RPC smoke: `initialize` + `tools/list` returns `outputSchema.type == "object"` with `pullRequests` required

## Spec-driven checklist

- [x] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code (or N/A for non-feature changes) — `docs/spec.md` and `docs/json-schema.md` updated to match the corrected output shape
- [x] No breaking changes to JSON output (see `docs/versioning.md`); the CLI `ccpr list --format json` output is unchanged. Only the MCP tool output is affected, and this is its first release so there are no prior consumers to break.

## Related issues

Follow-up to #55 / #56.