### PR TITLE
feat: add ccpr_review MCP tool

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -107,10 +107,11 @@ cp /path/to/ccpr/examples/claude/ccpr-review/SKILL.md .claude/skills/ccpr-review
 
 ### MCPサーバー
 
-ccpr は Claude Code などのMCPクライアント向けに、実験的なMCPサーバーバイナリも提供します。最初のtoolは読み取り専用です。
+ccpr は Claude Code などのMCPクライアント向けに、実験的なMCPサーバーバイナリも提供します。現在公開しているtool（いずれも読み取り専用）:
 
 ```text
-ccpr_list
+ccpr_list      リポジトリのPR一覧を取得
+ccpr_review    指定PRのメタデータ・コメント・diffをまとめて取得
 ```
 
 ローカルでビルドします。
@@ -125,7 +126,10 @@ Claude Codeに登録します。
 claude mcp add ccpr -- /path/to/ccpr/bin/ccpr-mcp
 ```
 
-その後、Claude CodeからCodeCommitのPR一覧取得を依頼できます。toolは `repo`, `status`, `region`, `profile`, `config` を受け取り、`ccpr list --format json` と同じPRサマリースキーマを返します。
+その後、Claude CodeからCodeCommitのPR一覧取得やレビュー対象PRの取得を依頼できます。
+
+- `ccpr_list` は `repo`, `status`, `region`, `profile`, `config` を受け取り、`ccpr list --format json` と同じPRサマリースキーマを `pullRequests` キー配下で返します。
+- `ccpr_review` は `url` または `repo` + `prId` のいずれかと、任意の `region`, `profile`, `config` を受け取り、`ccpr review --format json` と同じ `{metadata, comments, diff}` を返します。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,11 @@ See [docs/claude-integration.md](docs/claude-integration.md) for full setup guid
 
 ### MCP server
 
-ccpr also provides an experimental MCP server binary for Claude Code and other MCP clients. The first tool is read-only:
+ccpr also provides an experimental MCP server binary for Claude Code and other MCP clients. Currently exposed tools (read-only):
 
 ```text
-ccpr_list
+ccpr_list      List PRs for a repository
+ccpr_review    Fetch PR metadata, comments, and diff for a single PR
 ```
 
 Build it locally:
@@ -126,7 +127,10 @@ Register it with Claude Code:
 claude mcp add ccpr -- /path/to/ccpr/bin/ccpr-mcp
 ```
 
-Then ask Claude Code to list CodeCommit PRs for a repository. The tool accepts `repo`, `status`, `region`, `profile`, and `config`, and returns the same PR summary schema as `ccpr list --format json`.
+Then ask Claude Code to list or review CodeCommit PRs:
+
+- `ccpr_list` accepts `repo`, `status`, `region`, `profile`, and `config`, and returns the same PR summary schema as `ccpr list --format json` (wrapped under `pullRequests`).
+- `ccpr_review` accepts either `url` or `repo` + `prId`, plus optional `region`, `profile`, and `config`, and returns the same `{metadata, comments, diff}` payload as `ccpr review --format json`.
 
 ---
 

--- a/cmd/ccpr-mcp/main.go
+++ b/cmd/ccpr-mcp/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hidetzu/ccpr/internal/app"
 	"github.com/hidetzu/ccpr/internal/codecommit"
+	"github.com/hidetzu/ccpr/internal/diff"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -21,6 +22,15 @@ type listInput struct {
 
 type listOutput struct {
 	PullRequests []app.ListPullRequest `json:"pullRequests" jsonschema:"PR summaries for the repository"`
+}
+
+type reviewInput struct {
+	URL     string `json:"url,omitempty" jsonschema:"Full CodeCommit PR URL. When provided, takes priority for region, repo, and PR ID resolution."`
+	Repo    string `json:"repo,omitempty" jsonschema:"CodeCommit repository name. Required when url is not provided."`
+	PRId    string `json:"prId,omitempty" jsonschema:"Pull request ID. Required when url is not provided."`
+	Region  string `json:"region,omitempty" jsonschema:"AWS region override"`
+	Profile string `json:"profile,omitempty" jsonschema:"AWS profile name"`
+	Config  string `json:"config,omitempty" jsonschema:"Path to ccpr configuration file"`
 }
 
 func main() {
@@ -41,6 +51,11 @@ func newServer() *mcp.Server {
 		Description: "List AWS CodeCommit pull requests for a repository.",
 	}, listPullRequests)
 
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "ccpr_review",
+		Description: "Fetch a CodeCommit pull request's metadata, comments, and unified diff for AI-assisted review.",
+	}, reviewPullRequest)
+
 	return server
 }
 
@@ -58,6 +73,25 @@ func listPullRequests(ctx context.Context, _ *mcp.CallToolRequest, input listInp
 	return nil, listOutput{PullRequests: prs}, nil
 }
 
+func reviewPullRequest(ctx context.Context, _ *mcp.CallToolRequest, input reviewInput) (*mcp.CallToolResult, app.ReviewPayload, error) {
+	payload, err := app.GetReview(ctx, app.GetReviewOptions{
+		URL:     input.URL,
+		Repo:    input.Repo,
+		PRId:    input.PRId,
+		Region:  input.Region,
+		Profile: input.Profile,
+		Config:  input.Config,
+	}, newCodeCommitClient, defaultDiffGenerator)
+	if err != nil {
+		return nil, app.ReviewPayload{}, err
+	}
+	return nil, payload, nil
+}
+
 func newCodeCommitClient(ctx context.Context, region, profile string) (codecommit.Client, error) {
 	return codecommit.NewAWSClient(ctx, region, profile)
+}
+
+func defaultDiffGenerator() diff.Generator {
+	return &diff.GitGenerator{}
 }

--- a/cmd/ccpr/codecommit.go
+++ b/cmd/ccpr/codecommit.go
@@ -4,26 +4,9 @@ import (
 	"context"
 
 	"github.com/hidetzu/ccpr/internal/codecommit"
-	"github.com/hidetzu/ccpr/internal/output"
 )
 
 // newCodeCommitClient creates a CodeCommit client for the given region and profile.
 func newCodeCommitClient(ctx context.Context, region, profile string) (codecommit.Client, error) {
 	return codecommit.NewAWSClient(ctx, region, profile)
-}
-
-func convertComments(src []codecommit.Comment) []output.Comment {
-	out := make([]output.Comment, len(src))
-	for i, c := range src {
-		out[i] = output.Comment{
-			CommentId: c.CommentId,
-			InReplyTo: c.InReplyTo,
-			Author:    output.ShortAuthor(c.Author),
-			AuthorARN: c.Author,
-			Content:   c.Content,
-			Timestamp: c.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
-			FilePath:  c.FilePath,
-		}
-	}
-	return out
 }

--- a/cmd/ccpr/review.go
+++ b/cmd/ccpr/review.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hidetzu/ccpr/internal/config"
+	"github.com/hidetzu/ccpr/internal/app"
 	"github.com/hidetzu/ccpr/internal/diff"
 	"github.com/hidetzu/ccpr/internal/output"
-	"github.com/hidetzu/ccpr/internal/parser"
 )
 
 func runReview(args []string) error {
@@ -36,103 +35,36 @@ func runReview(args []string) error {
 		return err
 	}
 
-	// Validate format
 	switch flagFormat {
 	case "summary", "json", "patch":
 	default:
 		return fmt.Errorf("invalid format %q: must be summary, json, or patch", flagFormat)
 	}
 
-	// Resolve PR parameters: URL or explicit flags
-	var region, repo, prID string
-
-	if url := fs.Arg(0); url != "" {
-		result, err := parser.Parse(url)
-		if err != nil {
-			return fmt.Errorf("invalid PR URL: %w", err)
-		}
-		region = result.Region
-		repo = result.Repository
-		prID = result.PRId
-	} else if flagRepo != "" && flagPRId != "" {
-		repo = flagRepo
-		prID = flagPRId
-	} else {
-		return fmt.Errorf("provide a PR URL or --repo and --pr-id flags")
-	}
-
-	// Load config for repo mapping
-	cfg, _, err := config.Load(flagConfig)
-	if err != nil {
-		return fmt.Errorf("config: %w", err)
-	}
-
-	// Resolve region from flag or config (URL already sets it)
-	if region == "" {
-		region = cfg.ResolveRegion(flagRegion)
-	}
-	if region == "" {
-		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
-	}
-
-	repoPath, err := cfg.ResolveRepoPath(repo)
+	review, err := app.GetReview(context.Background(), app.GetReviewOptions{
+		URL:     fs.Arg(0),
+		Repo:    flagRepo,
+		PRId:    flagPRId,
+		Region:  flagRegion,
+		Profile: flagProfile,
+		Config:  flagConfig,
+	}, newCodeCommitClient, defaultDiffGenerator)
 	if err != nil {
 		return err
 	}
 
-	// Resolve AWS profile
-	profile := cfg.ResolveProfile(flagProfile)
-
-	// Fetch PR metadata and comments
-	ctx := context.Background()
-	cc, err := newCodeCommitClient(ctx, region, profile)
-	if err != nil {
-		return fmt.Errorf("creating CodeCommit client: %w", err)
-	}
-
-	metadata, err := cc.GetPRMetadata(ctx, repo, prID)
-	if err != nil {
-		return fmt.Errorf("fetching PR metadata: %w", err)
-	}
-
-	comments, err := cc.GetPRComments(ctx, repo, prID, metadata.DestinationCommit, metadata.SourceCommit)
-	if err != nil {
-		return fmt.Errorf("fetching PR comments: %w", err)
-	}
-
-	// Generate diff
-	gen := &diff.GitGenerator{}
-	diffText, err := gen.GenerateDiff(repoPath, metadata.SourceBranch, metadata.DestinationBranch)
-	if err != nil {
-		return fmt.Errorf("generating diff: %w", err)
-	}
-
-	// Build review output
-	review := output.ReviewOutput{
-		Metadata: output.PRMetadata{
-			PRId:              prID,
-			Title:             metadata.Title,
-			Description:       metadata.Description,
-			Author:            output.ShortAuthor(metadata.AuthorARN),
-			AuthorARN:         metadata.AuthorARN,
-			SourceBranch:      metadata.SourceBranch,
-			DestinationBranch: metadata.DestinationBranch,
-			Status:            metadata.Status,
-			CreationDate:      metadata.CreationDate.Format("2006-01-02T15:04:05Z07:00"),
-		},
-		Comments: convertComments(comments),
-		Diff:     diffText,
-	}
-
-	// Output
 	switch flagFormat {
 	case "patch":
-		return output.FormatPatch(os.Stdout, diffText)
+		return output.FormatPatch(os.Stdout, review.Diff)
 	case "json":
 		return output.FormatJSON(os.Stdout, review)
 	default:
 		return output.FormatSummary(os.Stdout, review)
 	}
+}
+
+func defaultDiffGenerator() diff.Generator {
+	return &diff.GitGenerator{}
 }
 
 // reorderArgs moves flags before positional args so Go's flag package

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -60,6 +60,8 @@ Top-level object combining PR metadata, comments, and diff.
 | `timestamp` | string | yes | ISO 8601 timestamp |
 | `filePath` | string | optional | File path (omitted for PR-level comments) |
 
+The MCP tool `ccpr_review` returns this same object directly; no wrapper is added because the payload is already an object.
+
 ---
 
 ### `list --format json`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -219,23 +219,34 @@ repoMappings:
 - Provide a separate MCP server binary at `cmd/ccpr-mcp`
 - The MCP server must not change the existing `ccpr` CLI behavior or JSON output
 - Transport: stdio
-- Exposed tools for the first MCP release:
-  - `ccpr_list` only
+- Exposed tools:
+  - `ccpr_list` — list pull requests (read-only)
+  - `ccpr_review` — fetch a PR's metadata, comments, and diff (read-only)
 - `ccpr_list` input mirrors `ccpr list` flags where applicable:
   - `repo` (required)
   - `status` (optional, default `open`; accepted values: `open`, `closed`, `all`)
   - `config` (optional)
   - `profile` (optional)
   - `region` (optional)
-- `ccpr_list` output must reuse the existing `ccpr list --format json` PR summary schema
+- `ccpr_list` output must reuse the existing `ccpr list --format json` PR summary schema (wrapped under `pullRequests` because MCP tool output schemas must be objects)
+- `ccpr_review` input mirrors `ccpr review` parameters:
+  - `url` (optional) — full CodeCommit PR URL; takes priority when present
+  - `repo` (optional) — required when `url` is not provided
+  - `prId` (optional) — required when `url` is not provided
+  - `region` (optional)
+  - `profile` (optional)
+  - `config` (optional)
+  - At least one of (`url`) or (`repo` and `prId`) must be provided
+- `ccpr_review` output must reuse the existing `ccpr review --format json` schema (`{metadata, comments, diff}`); no wrapper is needed because the payload is already an object
+- The MCP server exposes only the structured (JSON-equivalent) output. `summary` and `patch` formats remain CLI-only
 - AWS profile resolution follows FR-09
-- AWS region resolution follows FR-17
-- The implementation must share the internal list use case with the CLI so the CLI and MCP paths do not diverge
+- AWS region resolution follows FR-17, with one tool-specific exception: when `ccpr_review` is invoked with a `url`, the region embedded in the URL takes priority over `region`/config/env (matching `ccpr review` CLI behavior). Otherwise FR-17 applies as-is
+- The implementation must share the internal use cases with the CLI so the CLI and MCP paths do not diverge
 
 Constraints:
 - No write-side MCP tools in this feature
 - No new authentication or permission model in this feature
-- MCP versions of review, create, comment, open, and doctor are out of scope
+- MCP versions of create, comment, open, and doctor are out of scope
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -142,7 +142,11 @@ Flags:
 
 Invalid values cause the CLI to exit with code 1 and print an error to stderr.
 
-## Shared List Use Case
+## Shared Use Cases
+
+The CLI and the MCP server share command logic via `internal/app`. Each shared use case is responsible for input validation, config/profile/region resolution, AWS calls, and producing the same data structure both surfaces serialize.
+
+### List
 
 `ccpr list` and the `ccpr_list` MCP tool both call the same internal use case.
 
@@ -174,7 +178,36 @@ Behavior:
 5. Call `ListPRs`
 6. Return `[]ListPullRequest`
 
-This keeps the CLI summary/JSON rendering and the MCP tool response backed by the same data retrieval path.
+### Review
+
+`ccpr review` and the `ccpr_review` MCP tool both call the same internal use case.
+
+```go
+type GetReviewOptions struct {
+    URL     string
+    Repo    string
+    PRId    string
+    Region  string
+    Profile string
+    Config  string
+}
+
+// ReviewPayload mirrors output.ReviewOutput so the JSON shape stays
+// stable across the CLI and MCP paths.
+type ReviewPayload = output.ReviewOutput
+```
+
+Behavior:
+1. If `URL` is set, parse it to extract region, repo, and PR ID. Otherwise require `Repo` and `PRId`.
+2. Load config
+3. Resolve profile and region using the standard priority rules (URL-derived region wins when present)
+4. Resolve the local repo path via the config repo mapping
+5. Create a CodeCommit client
+6. Fetch PR metadata and PR comments
+7. Generate the unified diff via local Git (merge-base strategy, see "Diff Strategy")
+8. Return a `ReviewPayload` with `metadata`, `comments`, and `diff`
+
+This keeps the CLI summary/JSON/patch rendering and the MCP tool response backed by the same data retrieval path.
 
 ## MCP Server (FR-18)
 
@@ -236,9 +269,63 @@ Output schema:
 
 The MCP tool wraps the PR summary array in an object under `pullRequests` because MCP tool output schemas must be objects. Each element of `pullRequests` uses the same field names and types as `ccpr list --format json`. Consumers must ignore unknown fields for forward compatibility.
 
+### Tool: `ccpr_review`
+
+Fetches PR metadata, comments, and the local-Git-generated diff for a single pull request.
+
+Input schema:
+
+```json
+{
+  "url": "https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/pull-requests/42",
+  "repo": "my-repo",
+  "prId": "42",
+  "region": "ap-northeast-1",
+  "profile": "my-profile",
+  "config": "/path/to/config.yaml"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | conditional | | Full CodeCommit PR URL. When provided, takes priority for region/repo/PR ID resolution |
+| `repo` | string | conditional | | CodeCommit repository name. Required when `url` is not provided |
+| `prId` | string | conditional | | Pull request ID. Required when `url` is not provided |
+| `region` | string | no | | AWS region override |
+| `profile` | string | no | | AWS profile override |
+| `config` | string | no | | Path to ccpr config file |
+
+At least one of (`url`) or (`repo` and `prId`) must be provided.
+
+Output schema:
+
+```json
+{
+  "metadata": {
+    "prId": "42",
+    "title": "Add feature X",
+    "description": "...",
+    "author": "example",
+    "authorArn": "arn:aws:iam::123456789012:user/example",
+    "sourceBranch": "feature/x",
+    "destinationBranch": "main",
+    "status": "OPEN",
+    "creationDate": "2026-04-01T10:00:00Z"
+  },
+  "comments": [],
+  "diff": "diff --git a/... b/...\n..."
+}
+```
+
+The output is the same schema as `ccpr review --format json` (already an object, so no wrapper is needed). See `docs/json-schema.md` for the full field-level contract. Consumers must ignore unknown fields for forward compatibility.
+
+The MCP tool only exposes this structured shape. The CLI's `summary` and `patch` formats are not surfaced via MCP.
+
 ### Error Handling
 
-MCP tool errors are returned as tool call errors. Error messages follow the same validation and AWS/config guidance as the shared list use case:
+MCP tool errors are returned as tool call errors. Error messages follow the same validation and AWS/config guidance as the shared use cases.
+
+`ccpr_list`:
 
 - missing `repo`
 - invalid `status`
@@ -247,7 +334,18 @@ MCP tool errors are returned as tool call errors. Error messages follow the same
 - CodeCommit client creation failure
 - CodeCommit list failure
 
-Structured MCP-specific error codes are out of scope for the first MCP release.
+`ccpr_review`:
+
+- missing both `url` and (`repo` + `prId`)
+- invalid `url`
+- config load failure
+- missing region (when `url` does not supply one)
+- repo not mapped to a local Git path
+- CodeCommit client creation failure
+- PR metadata or comment fetch failure
+- local Git diff generation failure
+
+Structured MCP-specific error codes are out of scope for this release.
 
 ## Diff Strategy
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -179,11 +179,30 @@
   2. The client invokes the `ccpr_list` MCP tool with `repo` and optional `status`, `region`, `profile`, `config`
   3. `ccpr-mcp` resolves config, AWS profile, and AWS region using the same rules as `ccpr list`
   4. `ccpr-mcp` calls CodeCommit through the shared list use case
-  5. `ccpr-mcp` returns the same PR summary objects as `ccpr list --format json`
+  5. `ccpr-mcp` returns `{ "pullRequests": [...] }`, where each array item uses the same PR summary schema as `ccpr list --format json`
 - Success:
   - Claude Code can retrieve the PR list directly as a tool result and use it in the review workflow
 - Failure:
   - Missing repo → tool call returns a validation error
   - Missing region or invalid AWS credentials → tool call returns the same guidance as the CLI path
 - Note:
-  - This first MCP integration is read-only. MCP tools for review/create/comment/open are out of scope for this use case.
+  - This first MCP integration is read-only. Write-side MCP tools and MCP tools for create/comment/open remain out of scope for this use case.
+
+## UC-12 Review PR via MCP
+
+- Actor: Developer using Claude Code or another MCP client
+- Trigger: Developer wants the AI assistant to fetch a PR's metadata, comments, and diff for review without manually running `ccpr review --format json`
+- Precondition: `ccpr-mcp` is built and registered with the MCP client, AWS credentials are configured, config file maps the repo to a local Git path, region/profile are resolvable
+- Main flow:
+  1. Developer asks the MCP client to review a specific PR
+  2. The client invokes the `ccpr_review` MCP tool with either a `url` or `repo` + `prId` (plus optional `region`, `profile`, `config`)
+  3. `ccpr-mcp` resolves config, AWS profile, AWS region, and the local repo path using the same rules as `ccpr review`
+  4. `ccpr-mcp` fetches PR metadata and comments through CodeCommit and generates a unified diff via local Git through the shared review use case
+  5. `ccpr-mcp` returns the same `{metadata, comments, diff}` object as `ccpr review --format json`
+- Success:
+  - Claude Code receives the full review payload as a single structured tool result and proceeds to generate review feedback
+- Failure:
+  - Missing both `url` and `repo` + `prId` → tool call returns a validation error
+  - Missing region, missing repo mapping, invalid AWS credentials, or local Git diff failure → tool call returns the same guidance as the CLI path
+- Note:
+  - Only the structured (JSON-equivalent) output shape is exposed via MCP. The `summary` and `patch` formats remain CLI-only.

--- a/internal/app/review.go
+++ b/internal/app/review.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hidetzu/ccpr/internal/codecommit"
+	"github.com/hidetzu/ccpr/internal/config"
+	"github.com/hidetzu/ccpr/internal/diff"
+	"github.com/hidetzu/ccpr/internal/output"
+	"github.com/hidetzu/ccpr/internal/parser"
+)
+
+// DiffGeneratorFactory creates a diff generator for the resolved repo path.
+type DiffGeneratorFactory func() diff.Generator
+
+// GetReviewOptions contains inputs shared by the CLI and MCP review paths.
+type GetReviewOptions struct {
+	URL     string
+	Repo    string
+	PRId    string
+	Region  string
+	Profile string
+	Config  string
+}
+
+// ReviewPayload is the structured review payload returned to both the CLI
+// (for JSON formatting) and the MCP tool. It aliases output.ReviewOutput so
+// the JSON shape remains consistent across surfaces.
+type ReviewPayload = output.ReviewOutput
+
+// GetReview fetches PR metadata, comments, and the local-Git-generated diff
+// for a single pull request and returns it as a ReviewPayload.
+func GetReview(
+	ctx context.Context,
+	opts GetReviewOptions,
+	newClient CodeCommitClientFactory,
+	newDiff DiffGeneratorFactory,
+) (ReviewPayload, error) {
+	var region, repo, prID string
+
+	if opts.URL != "" {
+		result, err := parser.Parse(opts.URL)
+		if err != nil {
+			return ReviewPayload{}, fmt.Errorf("invalid PR URL: %w", err)
+		}
+		region = result.Region
+		repo = result.Repository
+		prID = result.PRId
+	} else if opts.Repo != "" && opts.PRId != "" {
+		repo = opts.Repo
+		prID = opts.PRId
+	} else {
+		return ReviewPayload{}, fmt.Errorf("provide a PR URL or repo and prId")
+	}
+
+	cfg, _, err := config.Load(opts.Config)
+	if err != nil {
+		return ReviewPayload{}, fmt.Errorf("config: %w", err)
+	}
+
+	if region == "" {
+		region = cfg.ResolveRegion(opts.Region)
+	}
+	if region == "" {
+		return ReviewPayload{}, fmt.Errorf("region is required: use region option, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+	}
+
+	repoPath, err := cfg.ResolveRepoPath(repo)
+	if err != nil {
+		return ReviewPayload{}, err
+	}
+
+	profile := cfg.ResolveProfile(opts.Profile)
+
+	cc, err := newClient(ctx, region, profile)
+	if err != nil {
+		return ReviewPayload{}, fmt.Errorf("creating CodeCommit client: %w", err)
+	}
+
+	metadata, err := cc.GetPRMetadata(ctx, repo, prID)
+	if err != nil {
+		return ReviewPayload{}, fmt.Errorf("fetching PR metadata: %w", err)
+	}
+
+	comments, err := cc.GetPRComments(ctx, repo, prID, metadata.DestinationCommit, metadata.SourceCommit)
+	if err != nil {
+		return ReviewPayload{}, fmt.Errorf("fetching PR comments: %w", err)
+	}
+
+	gen := newDiff()
+	diffText, err := gen.GenerateDiff(repoPath, metadata.SourceBranch, metadata.DestinationBranch)
+	if err != nil {
+		return ReviewPayload{}, fmt.Errorf("generating diff: %w", err)
+	}
+
+	return ReviewPayload{
+		Metadata: output.PRMetadata{
+			PRId:              prID,
+			Title:             metadata.Title,
+			Description:       metadata.Description,
+			Author:            output.ShortAuthor(metadata.AuthorARN),
+			AuthorARN:         metadata.AuthorARN,
+			SourceBranch:      metadata.SourceBranch,
+			DestinationBranch: metadata.DestinationBranch,
+			Status:            metadata.Status,
+			CreationDate:      metadata.CreationDate.Format("2006-01-02T15:04:05Z07:00"),
+		},
+		Comments: convertComments(comments),
+		Diff:     diffText,
+	}, nil
+}
+
+func convertComments(src []codecommit.Comment) []output.Comment {
+	out := make([]output.Comment, len(src))
+	for i, c := range src {
+		out[i] = output.Comment{
+			CommentId: c.CommentId,
+			InReplyTo: c.InReplyTo,
+			Author:    output.ShortAuthor(c.Author),
+			AuthorARN: c.Author,
+			Content:   c.Content,
+			Timestamp: c.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
+			FilePath:  c.FilePath,
+		}
+	}
+	return out
+}

--- a/internal/app/review_test.go
+++ b/internal/app/review_test.go
@@ -1,0 +1,224 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hidetzu/ccpr/internal/codecommit"
+	"github.com/hidetzu/ccpr/internal/diff"
+)
+
+type fakeReviewClient struct {
+	metadata          codecommit.PRMetadata
+	comments          []codecommit.Comment
+	gotMetadataRepo   string
+	gotMetadataPRID   string
+	gotCommentsRepo   string
+	gotCommentsPRID   string
+	gotCommentsBefore string
+	gotCommentsAfter  string
+}
+
+func (f *fakeReviewClient) GetPRMetadata(_ context.Context, repo, prID string) (codecommit.PRMetadata, error) {
+	f.gotMetadataRepo = repo
+	f.gotMetadataPRID = prID
+	return f.metadata, nil
+}
+
+func (f *fakeReviewClient) GetPRComments(_ context.Context, repo, prID, before, after string) ([]codecommit.Comment, error) {
+	f.gotCommentsRepo = repo
+	f.gotCommentsPRID = prID
+	f.gotCommentsBefore = before
+	f.gotCommentsAfter = after
+	return f.comments, nil
+}
+
+func (f *fakeReviewClient) ListPRs(context.Context, string, string) ([]codecommit.PRSummary, error) {
+	return nil, nil
+}
+
+func (f *fakeReviewClient) PostComment(context.Context, string, string, string, string, string) (codecommit.PostCommentResult, error) {
+	return codecommit.PostCommentResult{}, nil
+}
+
+func (f *fakeReviewClient) CreatePR(context.Context, string, string, string, string, string) (codecommit.CreatePRResult, error) {
+	return codecommit.CreatePRResult{}, nil
+}
+
+type fakeDiffGen struct {
+	diff       string
+	err        error
+	gotRepo    string
+	gotSource  string
+	gotDestBr  string
+	called     bool
+}
+
+func (f *fakeDiffGen) GenerateDiff(repoPath, sourceBranch, destBranch string) (string, error) {
+	f.called = true
+	f.gotRepo = repoPath
+	f.gotSource = sourceBranch
+	f.gotDestBr = destBranch
+	return f.diff, f.err
+}
+
+func TestGetReviewRequiresURLOrRepoAndPRId(t *testing.T) {
+	_, err := GetReview(context.Background(), GetReviewOptions{}, nil, nil)
+	if err == nil {
+		t.Fatal("GetReview returned nil error")
+	}
+	if !strings.Contains(err.Error(), "URL or repo and prId") {
+		t.Fatalf("error = %q, want URL/repo guidance", err.Error())
+	}
+}
+
+func TestGetReviewRejectsInvalidURL(t *testing.T) {
+	_, err := GetReview(context.Background(), GetReviewOptions{URL: "not-a-url"}, nil, nil)
+	if err == nil {
+		t.Fatal("GetReview returned nil error")
+	}
+	if !strings.Contains(err.Error(), "invalid PR URL") {
+		t.Fatalf("error = %q, want invalid URL", err.Error())
+	}
+}
+
+func TestGetReviewURLDrivesRegionAndBuildsPayload(t *testing.T) {
+	configPath := writeListConfig(t, "region: us-east-1\nrepoMappings:\n  my-repo: /tmp/my-repo\n")
+	created := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	commented := time.Date(2026, 4, 2, 9, 30, 0, 0, time.UTC)
+
+	cc := &fakeReviewClient{
+		metadata: codecommit.PRMetadata{
+			Title:             "Add feature X",
+			Description:       "desc",
+			AuthorARN:         "arn:aws:iam::123456789012:user/example",
+			SourceBranch:      "feature/x",
+			DestinationBranch: "main",
+			SourceCommit:      "src-commit",
+			DestinationCommit: "dst-commit",
+			Status:            "OPEN",
+			CreationDate:      created,
+		},
+		comments: []codecommit.Comment{{
+			CommentId: "c1",
+			Author:    "arn:aws:iam::123456789012:user/example",
+			Content:   "looks good",
+			Timestamp: commented,
+		}},
+	}
+	dg := &fakeDiffGen{diff: "diff text"}
+
+	gotRegion := ""
+	got, err := GetReview(context.Background(), GetReviewOptions{
+		URL:    "https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/pull-requests/42",
+		Config: configPath,
+	}, func(_ context.Context, region, _ string) (codecommit.Client, error) {
+		gotRegion = region
+		return cc, nil
+	}, func() diff.Generator {
+		return dg
+	})
+	if err != nil {
+		t.Fatalf("GetReview returned error: %v", err)
+	}
+
+	if gotRegion != "ap-northeast-1" {
+		t.Fatalf("region passed to client factory = %q, want ap-northeast-1 (URL wins over config)", gotRegion)
+	}
+	if cc.gotMetadataRepo != "my-repo" || cc.gotMetadataPRID != "42" {
+		t.Fatalf("GetPRMetadata called with repo=%q prID=%q", cc.gotMetadataRepo, cc.gotMetadataPRID)
+	}
+	if cc.gotCommentsBefore != "dst-commit" || cc.gotCommentsAfter != "src-commit" {
+		t.Fatalf("GetPRComments called with before=%q after=%q", cc.gotCommentsBefore, cc.gotCommentsAfter)
+	}
+	if !dg.called {
+		t.Fatal("diff generator was not invoked")
+	}
+	if dg.gotRepo != "/tmp/my-repo" || dg.gotSource != "feature/x" || dg.gotDestBr != "main" {
+		t.Fatalf("GenerateDiff called with repo=%q source=%q dest=%q", dg.gotRepo, dg.gotSource, dg.gotDestBr)
+	}
+
+	if got.Metadata.PRId != "42" || got.Metadata.Title != "Add feature X" {
+		t.Fatalf("metadata = %+v", got.Metadata)
+	}
+	if got.Metadata.Author != "example" {
+		t.Fatalf("Author = %q, want short form 'example'", got.Metadata.Author)
+	}
+	if got.Metadata.CreationDate != "2026-04-01T10:00:00Z" {
+		t.Fatalf("CreationDate = %q", got.Metadata.CreationDate)
+	}
+	if got.Diff != "diff text" {
+		t.Fatalf("Diff = %q", got.Diff)
+	}
+	if len(got.Comments) != 1 || got.Comments[0].Timestamp != "2026-04-02T09:30:00Z" {
+		t.Fatalf("comments = %+v", got.Comments)
+	}
+}
+
+func TestGetReviewRepoPRIdUsesConfigRegion(t *testing.T) {
+	configPath := writeListConfig(t, "region: ap-northeast-1\nrepoMappings:\n  my-repo: /tmp/my-repo\n")
+	cc := &fakeReviewClient{
+		metadata: codecommit.PRMetadata{
+			SourceBranch:      "feature/x",
+			DestinationBranch: "main",
+			CreationDate:      time.Now(),
+		},
+	}
+	dg := &fakeDiffGen{diff: "ok"}
+
+	gotRegion := ""
+	_, err := GetReview(context.Background(), GetReviewOptions{
+		Repo:   "my-repo",
+		PRId:   "42",
+		Config: configPath,
+	}, func(_ context.Context, region, _ string) (codecommit.Client, error) {
+		gotRegion = region
+		return cc, nil
+	}, func() diff.Generator { return dg })
+	if err != nil {
+		t.Fatalf("GetReview returned error: %v", err)
+	}
+	if gotRegion != "ap-northeast-1" {
+		t.Fatalf("region = %q, want ap-northeast-1 from config", gotRegion)
+	}
+}
+
+func TestGetReviewSurfacesRepoMappingError(t *testing.T) {
+	configPath := writeListConfig(t, "region: ap-northeast-1\n")
+	_, err := GetReview(context.Background(), GetReviewOptions{
+		Repo:   "unmapped-repo",
+		PRId:   "42",
+		Config: configPath,
+	}, func(context.Context, string, string) (codecommit.Client, error) {
+		return &fakeReviewClient{}, nil
+	}, func() diff.Generator { return &fakeDiffGen{} })
+	if err == nil || !strings.Contains(err.Error(), "no local path mapping") {
+		t.Fatalf("error = %v, want repo mapping failure", err)
+	}
+}
+
+func TestGetReviewSurfacesDiffError(t *testing.T) {
+	configPath := writeListConfig(t, "region: ap-northeast-1\nrepoMappings:\n  my-repo: /tmp/my-repo\n")
+	cc := &fakeReviewClient{
+		metadata: codecommit.PRMetadata{
+			SourceBranch:      "feature/x",
+			DestinationBranch: "main",
+			CreationDate:      time.Now(),
+		},
+	}
+	dg := &fakeDiffGen{err: errors.New("boom")}
+
+	_, err := GetReview(context.Background(), GetReviewOptions{
+		Repo:   "my-repo",
+		PRId:   "42",
+		Config: configPath,
+	}, func(context.Context, string, string) (codecommit.Client, error) {
+		return cc, nil
+	}, func() diff.Generator { return dg })
+	if err == nil || !strings.Contains(err.Error(), "generating diff") {
+		t.Fatalf("error = %v, want diff generation failure", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Expose `ccpr review --format json` over MCP as a new `ccpr_review` tool, served by the existing `ccpr-mcp` binary alongside `ccpr_list`.
- Extract the review pipeline into `internal/app/review.go` so the CLI and MCP paths share input parsing, AWS profile/region resolution, PR metadata/comment fetching, and local-Git diff generation. The existing `ccpr review --format json` schema is preserved unchanged.
- Inject a diff generator factory and add unit tests covering URL/repo+prId routing, region precedence (URL wins over config), repo-mapping errors, and diff failures, so the new use case is exercised without invoking real `git`.
- Update `docs/use-cases.md` (UC-12), `docs/requirements.md` (FR-18), `docs/spec.md`, `docs/json-schema.md`, and the READMEs to document the new tool, including the URL-derived region exception to FR-17.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change
- [x] Documentation (`docs:`)
- [x] Refactor / chore (`refactor:` / `chore:`)
- [x] Test (`test:`)

(Primary type: `feat:`. Refactor extracts the review pipeline; docs and tests are part of the same change.)

## Test plan

- [x] `make build` / `make build-mcp` / `make test` / `make vet` / `make lint` all pass
- [x] `go test ./internal/app/...` covers `GetReview` happy path, validation errors, and propagated failures
- [x] CLI golden tests under `cmd/ccpr/testdata/` continue to pass (no JSON output regression)
- [x] Manual JSON-RPC smoke: `initialize` + `tools/list` returns both `ccpr_list` and `ccpr_review` with `outputSchema.type == "object"`
- [ ] End-to-end smoke via Claude Code MCP registration against a real CodeCommit PR

## Spec-driven checklist

- [x] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code
- [x] No breaking changes to JSON output (see `docs/versioning.md`); the CLI `ccpr review --format json` payload is unchanged. The MCP tool returns the same object directly (no wrapper needed because it is already an object).

## Related issues

Closes #58.