### PR TITLE
feat: add ccpr_comment MCP tool

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -107,11 +107,12 @@ cp /path/to/ccpr/examples/claude/ccpr-review/SKILL.md .claude/skills/ccpr-review
 
 ### MCPサーバー
 
-ccpr は Claude Code などのMCPクライアント向けに、実験的なMCPサーバーバイナリも提供します。現在公開しているtool（いずれも読み取り専用）:
+ccpr は Claude Code などのMCPクライアント向けに、実験的なMCPサーバーバイナリも提供します。現在公開しているtool:
 
 ```text
-ccpr_list      リポジトリのPR一覧を取得
-ccpr_review    指定PRのメタデータ・コメント・diffをまとめて取得
+ccpr_list      リポジトリのPR一覧を取得          (読み取り)
+ccpr_review    指定PRのメタデータ・コメント・diffをまとめて取得  (読み取り)
+ccpr_comment   PRにコメントを投稿                (書き込み)
 ```
 
 ローカルでビルドします。
@@ -130,6 +131,7 @@ claude mcp add ccpr -- /path/to/ccpr/bin/ccpr-mcp
 
 - `ccpr_list` は `repo`, `status`, `region`, `profile`, `config` を受け取り、`ccpr list --format json` と同じPRサマリースキーマを `pullRequests` キー配下で返します。
 - `ccpr_review` は `url` または `repo` + `prId` のいずれかと、任意の `region`, `profile`, `config` を受け取り、`ccpr review --format json` と同じ `{metadata, comments, diff}` を返します。
+- `ccpr_comment` は `body` と、`url` または `repo` + `prId`、任意の `region`, `profile`, `config` を受け取り、`ccpr comment --format json` と同じ `{commentId, pullRequestId, authorArn, creationDate}` を返します。**書き込み系**のため、呼び出すたびにCodeCommitへ実際にコメントが投稿されます。MCPホスト側の承認プロンプトで明示的に許可してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,12 @@ See [docs/claude-integration.md](docs/claude-integration.md) for full setup guid
 
 ### MCP server
 
-ccpr also provides an experimental MCP server binary for Claude Code and other MCP clients. Currently exposed tools (read-only):
+ccpr also provides an experimental MCP server binary for Claude Code and other MCP clients. Currently exposed tools:
 
 ```text
-ccpr_list      List PRs for a repository
-ccpr_review    Fetch PR metadata, comments, and diff for a single PR
+ccpr_list      List PRs for a repository                     (read-only)
+ccpr_review    Fetch PR metadata, comments, and diff         (read-only)
+ccpr_comment   Post a comment to a PR                        (write-side)
 ```
 
 Build it locally:
@@ -131,6 +132,7 @@ Then ask Claude Code to list or review CodeCommit PRs:
 
 - `ccpr_list` accepts `repo`, `status`, `region`, `profile`, and `config`, and returns the same PR summary schema as `ccpr list --format json` (wrapped under `pullRequests`).
 - `ccpr_review` accepts either `url` or `repo` + `prId`, plus optional `region`, `profile`, and `config`, and returns the same `{metadata, comments, diff}` payload as `ccpr review --format json`.
+- `ccpr_comment` accepts `body` and either `url` or `repo` + `prId`, plus optional `region`, `profile`, and `config`, and returns the same `{commentId, pullRequestId, authorArn, creationDate}` payload as `ccpr comment --format json`. **Write-side**: each successful call posts a real comment to CodeCommit, so MCP hosts should prompt before invocation.
 
 ---
 

--- a/cmd/ccpr-mcp/main.go
+++ b/cmd/ccpr-mcp/main.go
@@ -33,6 +33,16 @@ type reviewInput struct {
 	Config  string `json:"config,omitempty" jsonschema:"Path to ccpr configuration file"`
 }
 
+type commentInput struct {
+	URL     string `json:"url,omitempty" jsonschema:"Full CodeCommit PR URL. When provided, takes priority for region, repo, and PR ID resolution."`
+	Repo    string `json:"repo,omitempty" jsonschema:"CodeCommit repository name. Required when url is not provided."`
+	PRId    string `json:"prId,omitempty" jsonschema:"Pull request ID. Required when url is not provided."`
+	Body    string `json:"body" jsonschema:"Comment body. Each successful call posts a real comment to the PR."`
+	Region  string `json:"region,omitempty" jsonschema:"AWS region override"`
+	Profile string `json:"profile,omitempty" jsonschema:"AWS profile name"`
+	Config  string `json:"config,omitempty" jsonschema:"Path to ccpr configuration file"`
+}
+
 func main() {
 	server := newServer()
 	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
@@ -55,6 +65,11 @@ func newServer() *mcp.Server {
 		Name:        "ccpr_review",
 		Description: "Fetch a CodeCommit pull request's metadata, comments, and unified diff for AI-assisted review.",
 	}, reviewPullRequest)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "ccpr_comment",
+		Description: "Post a comment to a CodeCommit pull request. WRITE-SIDE: each successful call creates a real comment, so the host should prompt the user before invocation.",
+	}, postPullRequestComment)
 
 	return server
 }
@@ -86,6 +101,22 @@ func reviewPullRequest(ctx context.Context, _ *mcp.CallToolRequest, input review
 		return nil, app.ReviewPayload{}, err
 	}
 	return nil, payload, nil
+}
+
+func postPullRequestComment(ctx context.Context, _ *mcp.CallToolRequest, input commentInput) (*mcp.CallToolResult, app.PostedComment, error) {
+	posted, err := app.PostComment(ctx, app.PostCommentOptions{
+		URL:     input.URL,
+		Repo:    input.Repo,
+		PRId:    input.PRId,
+		Body:    input.Body,
+		Region:  input.Region,
+		Profile: input.Profile,
+		Config:  input.Config,
+	}, newCodeCommitClient)
+	if err != nil {
+		return nil, app.PostedComment{}, err
+	}
+	return nil, posted, nil
 }
 
 func newCodeCommitClient(ctx context.Context, region, profile string) (codecommit.Client, error) {

--- a/cmd/ccpr/comment.go
+++ b/cmd/ccpr/comment.go
@@ -8,9 +8,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/hidetzu/ccpr/internal/config"
+	"github.com/hidetzu/ccpr/internal/app"
 	"github.com/hidetzu/ccpr/internal/output"
-	"github.com/hidetzu/ccpr/internal/parser"
 )
 
 func runComment(args []string) error {
@@ -41,75 +40,34 @@ func runComment(args []string) error {
 		return err
 	}
 
-	// Validate format
 	switch flagFormat {
 	case "summary", "json":
 	default:
 		return fmt.Errorf("invalid format %q: must be summary or json", flagFormat)
 	}
 
-	// Resolve body
 	body, err := resolveBody(flagBody, flagBodyFile)
 	if err != nil {
 		return err
 	}
 
-	// Resolve PR parameters
-	var region, repo, prID string
-
-	if url := fs.Arg(0); url != "" {
-		result, err := parser.Parse(url)
-		if err != nil {
-			return fmt.Errorf("invalid PR URL: %w", err)
-		}
-		region = result.Region
-		repo = result.Repository
-		prID = result.PRId
-	} else if flagRepo != "" && flagPRId != "" {
-		repo = flagRepo
-		prID = flagPRId
-	} else {
-		return fmt.Errorf("provide a PR URL or --repo and --pr-id flags")
-	}
-
-	// Load config
-	cfg, _, err := config.Load(flagConfig)
+	result, err := app.PostComment(context.Background(), app.PostCommentOptions{
+		URL:     fs.Arg(0),
+		Repo:    flagRepo,
+		PRId:    flagPRId,
+		Body:    body,
+		Region:  flagRegion,
+		Profile: flagProfile,
+		Config:  flagConfig,
+	}, newCodeCommitClient)
 	if err != nil {
-		return fmt.Errorf("config: %w", err)
+		return err
 	}
 
-	if region == "" {
-		region = cfg.ResolveRegion(flagRegion)
-	}
-	if region == "" {
-		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
-	}
-	profile := cfg.ResolveProfile(flagProfile)
-
-	// Get PR metadata for commit IDs
-	ctx := context.Background()
-	cc, err := newCodeCommitClient(ctx, region, profile)
-	if err != nil {
-		return newSystemError("creating CodeCommit client: %w", err)
-	}
-
-	metadata, err := cc.GetPRMetadata(ctx, repo, prID)
-	if err != nil {
-		return newSystemError("fetching PR metadata: %w", err)
-	}
-
-	// Post comment
-	result, err := cc.PostComment(ctx, repo, prID, metadata.DestinationCommit, metadata.SourceCommit, body)
-	if err != nil {
-		return newSystemError("posting comment: %w", err)
-	}
-
-	// Output
-	creationDate := result.CreationDate.Format("2006-01-02T15:04:05Z07:00")
 	if flagFormat == "json" {
-		return printCommentJSON(os.Stdout, prID, result.CommentID, result.AuthorARN, creationDate)
+		return printCommentJSON(os.Stdout, result)
 	}
-	return printCommentSummary(os.Stdout, prID, result.CommentID, output.ShortAuthor(result.AuthorARN), creationDate)
+	return printCommentSummary(os.Stdout, result.PullRequestID, result.CommentID, output.ShortAuthor(result.AuthorARN), result.CreationDate)
 }
 
 func resolveBody(flagBody, flagBodyFile string) (string, error) {
@@ -140,23 +98,10 @@ func resolveBody(flagBody, flagBodyFile string) (string, error) {
 	return "", fmt.Errorf("provide comment body via --body or --body-file")
 }
 
-type commentJSONOutput struct {
-	CommentID     string `json:"commentId"`
-	PullRequestID string `json:"pullRequestId"`
-	AuthorARN     string `json:"authorArn"`
-	CreationDate  string `json:"creationDate"`
-}
-
-func printCommentJSON(w io.Writer, prID string, commentID, authorARN string, creationDate string) error {
-	out := commentJSONOutput{
-		CommentID:     commentID,
-		PullRequestID: prID,
-		AuthorARN:     authorARN,
-		CreationDate:  creationDate,
-	}
+func printCommentJSON(w io.Writer, result app.PostedComment) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	return enc.Encode(result)
 }
 
 func printCommentSummary(w io.Writer, prID, commentID, author, creationDate string) error {

--- a/cmd/ccpr/comment_test.go
+++ b/cmd/ccpr/comment_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/hidetzu/ccpr/internal/app"
 )
 
 func TestResolveBody_Inline(t *testing.T) {
@@ -128,7 +130,12 @@ func TestPrintCommentSummary(t *testing.T) {
 
 func TestPrintCommentJSON(t *testing.T) {
 	var buf bytes.Buffer
-	err := printCommentJSON(&buf, "123", "abc-def", "arn:aws:iam::123456789012:user/test", "2026-03-31T17:00:00Z")
+	err := printCommentJSON(&buf, app.PostedComment{
+		CommentID:     "abc-def",
+		PullRequestID: "123",
+		AuthorARN:     "arn:aws:iam::123456789012:user/test",
+		CreationDate:  "2026-03-31T17:00:00Z",
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/ccpr/golden_test.go
+++ b/cmd/ccpr/golden_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hidetzu/ccpr/internal/app"
 	"github.com/hidetzu/ccpr/internal/output"
 )
 
@@ -171,7 +172,12 @@ func TestGolden_ListJSON_Empty(t *testing.T) {
 
 func TestGolden_CommentJSON(t *testing.T) {
 	var buf bytes.Buffer
-	if err := printCommentJSON(&buf, "42", "eb596ff8-5133-438f-88d6-7c94f693302b", "arn:aws:iam::123:user/dev", "2026-04-01T10:00:00+09:00"); err != nil {
+	if err := printCommentJSON(&buf, app.PostedComment{
+		CommentID:     "eb596ff8-5133-438f-88d6-7c94f693302b",
+		PullRequestID: "42",
+		AuthorARN:     "arn:aws:iam::123:user/dev",
+		CreationDate:  "2026-04-01T10:00:00+09:00",
+	}); err != nil {
 		t.Fatalf("printCommentJSON error: %v", err)
 	}
 
@@ -313,7 +319,12 @@ func TestGolden_Indentation(t *testing.T) {
 			name: "comment",
 			output: func() string {
 				var buf bytes.Buffer
-				_ = printCommentJSON(&buf, "1", "c1", "arn", "2026-01-01T00:00:00Z")
+				_ = printCommentJSON(&buf, app.PostedComment{
+					CommentID:     "c1",
+					PullRequestID: "1",
+					AuthorARN:     "arn",
+					CreationDate:  "2026-01-01T00:00:00Z",
+				})
 				return buf.String()
 			},
 		},

--- a/cmd/ccpr/main.go
+++ b/cmd/ccpr/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+
+	"github.com/hidetzu/ccpr/internal/app"
 )
 
 // systemError represents a system-level error (AWS, Git) that should exit with code 2.
@@ -24,6 +26,10 @@ func newSystemError(format string, a ...any) error {
 func exitCode(err error) int {
 	var sysErr *systemError
 	if errors.As(err, &sysErr) {
+		return 2
+	}
+	var appSysErr *app.SystemError
+	if errors.As(err, &appSysErr) {
 		return 2
 	}
 	return 1

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -118,6 +118,8 @@ Result of posting a comment.
 | `authorArn` | string | yes | Full IAM ARN of the commenter |
 | `creationDate` | string | yes | ISO 8601 timestamp |
 
+The MCP tool `ccpr_comment` returns this same object directly; no wrapper is added because the payload is already an object.
+
 ---
 
 ### `create --format json`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -222,6 +222,7 @@ repoMappings:
 - Exposed tools:
   - `ccpr_list` — list pull requests (read-only)
   - `ccpr_review` — fetch a PR's metadata, comments, and diff (read-only)
+  - `ccpr_comment` — post a comment to a pull request (write-side)
 - `ccpr_list` input mirrors `ccpr list` flags where applicable:
   - `repo` (required)
   - `status` (optional, default `open`; accepted values: `open`, `closed`, `all`)
@@ -238,15 +239,25 @@ repoMappings:
   - `config` (optional)
   - At least one of (`url`) or (`repo` and `prId`) must be provided
 - `ccpr_review` output must reuse the existing `ccpr review --format json` schema (`{metadata, comments, diff}`); no wrapper is needed because the payload is already an object
-- The MCP server exposes only the structured (JSON-equivalent) output. `summary` and `patch` formats remain CLI-only
+- `ccpr_comment` input mirrors `ccpr comment` parameters:
+  - `url` (optional) — full CodeCommit PR URL; takes priority when present
+  - `repo` (optional) — required when `url` is not provided
+  - `prId` (optional) — required when `url` is not provided
+  - `body` (required) — comment body
+  - `region` (optional)
+  - `profile` (optional)
+  - `config` (optional)
+  - At least one of (`url`) or (`repo` and `prId`) must be provided
+- `ccpr_comment` output must reuse the existing `ccpr comment --format json` schema (`{commentId, pullRequestId, authorArn, creationDate}`); no wrapper is needed because the payload is already an object
+- `ccpr_comment` is write-side: each successful call posts a real comment to CodeCommit. The tool description and README must call this out so MCP hosts can prompt users before invocation
+- The MCP server exposes only the structured (JSON-equivalent) output. `summary`, `patch`, `--body-file`, and stdin (`-`) input forms remain CLI-only
 - AWS profile resolution follows FR-09
-- AWS region resolution follows FR-17, with one tool-specific exception: when `ccpr_review` is invoked with a `url`, the region embedded in the URL takes priority over `region`/config/env (matching `ccpr review` CLI behavior). Otherwise FR-17 applies as-is
+- AWS region resolution follows FR-17, with the following tool-specific exception: when `ccpr_review` or `ccpr_comment` is invoked with a `url`, the region embedded in the URL takes priority over `region`/config/env (matching the corresponding CLI behavior). Otherwise FR-17 applies as-is
 - The implementation must share the internal use cases with the CLI so the CLI and MCP paths do not diverge
 
 Constraints:
-- No write-side MCP tools in this feature
-- No new authentication or permission model in this feature
-- MCP versions of create, comment, open, and doctor are out of scope
+- No new authentication or permission model — write-side MCP tools rely on the MCP host's per-call approval gate plus the same AWS profile resolution as the CLI
+- MCP versions of `create`, `open`, and `doctor` are out of scope for this feature
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -209,6 +209,41 @@ Behavior:
 
 This keeps the CLI summary/JSON/patch rendering and the MCP tool response backed by the same data retrieval path.
 
+### Comment
+
+`ccpr comment` and the `ccpr_comment` MCP tool both call the same internal use case.
+
+```go
+type PostCommentOptions struct {
+    URL     string
+    Repo    string
+    PRId    string
+    Body    string
+    Region  string
+    Profile string
+    Config  string
+}
+
+type PostedComment struct {
+    CommentID     string `json:"commentId"`
+    PullRequestID string `json:"pullRequestId"`
+    AuthorARN     string `json:"authorArn"`
+    CreationDate  string `json:"creationDate"`
+}
+```
+
+Behavior:
+1. Validate `Body` is non-empty
+2. If `URL` is set, parse it to extract region, repo, and PR ID. Otherwise require `Repo` and `PRId`
+3. Load config
+4. Resolve profile and region using the standard priority rules (URL-derived region wins when present)
+5. Create a CodeCommit client
+6. Fetch PR metadata to obtain `DestinationCommit` and `SourceCommit`
+7. Call `PostComment(repo, prID, before=DestinationCommit, after=SourceCommit, body)`
+8. Return a `PostedComment` with the new `CommentID`, the original `PRId`, the author ARN, and the formatted creation timestamp
+
+This keeps the CLI summary/JSON rendering and the MCP tool response backed by the same write path.
+
 ## MCP Server (FR-18)
 
 ### Binary
@@ -321,6 +356,51 @@ The output is the same schema as `ccpr review --format json` (already an object,
 
 The MCP tool only exposes this structured shape. The CLI's `summary` and `patch` formats are not surfaced via MCP.
 
+### Tool: `ccpr_comment`
+
+Posts a comment to a CodeCommit pull request. **Write-side**: each successful call creates a real comment in CodeCommit, so MCP hosts should prompt users before invocation.
+
+Input schema:
+
+```json
+{
+  "url": "https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/pull-requests/42",
+  "repo": "my-repo",
+  "prId": "42",
+  "body": "Looks good to me.",
+  "region": "ap-northeast-1",
+  "profile": "my-profile",
+  "config": "/path/to/config.yaml"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | conditional | | Full CodeCommit PR URL. When provided, takes priority for region/repo/PR ID resolution |
+| `repo` | string | conditional | | CodeCommit repository name. Required when `url` is not provided |
+| `prId` | string | conditional | | Pull request ID. Required when `url` is not provided |
+| `body` | string | yes | | Comment body |
+| `region` | string | no | | AWS region override |
+| `profile` | string | no | | AWS profile override |
+| `config` | string | no | | Path to ccpr config file |
+
+At least one of (`url`) or (`repo` and `prId`) must be provided. `body` must be non-empty.
+
+Output schema:
+
+```json
+{
+  "commentId": "eb596ff8-5133-438f-88d6-7c94f693302b",
+  "pullRequestId": "42",
+  "authorArn": "arn:aws:iam::123456789012:user/example",
+  "creationDate": "2026-05-04T10:00:00Z"
+}
+```
+
+The output is the same schema as `ccpr comment --format json` (already an object, so no wrapper is needed).
+
+The MCP tool only exposes this structured shape. The CLI's `summary` format, `--body-file` flag, and stdin (`-`) input form remain CLI-only.
+
 ### Error Handling
 
 MCP tool errors are returned as tool call errors. Error messages follow the same validation and AWS/config guidance as the shared use cases.
@@ -344,6 +424,17 @@ MCP tool errors are returned as tool call errors. Error messages follow the same
 - CodeCommit client creation failure
 - PR metadata or comment fetch failure
 - local Git diff generation failure
+
+`ccpr_comment`:
+
+- missing `body`
+- missing both `url` and (`repo` + `prId`)
+- invalid `url`
+- config load failure
+- missing region (when `url` does not supply one)
+- CodeCommit client creation failure
+- PR metadata fetch failure
+- `PostComment` failure
 
 Structured MCP-specific error codes are out of scope for this release.
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -206,3 +206,24 @@
   - Missing region, missing repo mapping, invalid AWS credentials, or local Git diff failure → tool call returns the same guidance as the CLI path
 - Note:
   - Only the structured (JSON-equivalent) output shape is exposed via MCP. The `summary` and `patch` formats remain CLI-only.
+
+## UC-13 Post a PR Comment via MCP
+
+- Actor: Developer using Claude Code or another MCP client
+- Trigger: After reviewing a PR with `ccpr_review`, the AI assistant has feedback ready and the developer wants to post it back to the PR without dropping to the shell
+- Precondition: `ccpr-mcp` is built and registered with the MCP client, AWS credentials are configured, region/profile are resolvable, and the MCP host is configured to prompt the user before invoking write-side tools
+- Main flow:
+  1. Developer instructs the MCP client to post a review comment on a specific PR
+  2. The client invokes the `ccpr_comment` MCP tool with `body` plus either a `url` or `repo` + `prId` (and optional `region`, `profile`, `config`)
+  3. The MCP host prompts the user to approve the call (because the tool is write-side)
+  4. `ccpr-mcp` resolves config, AWS profile, and AWS region using the same rules as `ccpr comment`
+  5. `ccpr-mcp` fetches PR metadata to obtain the source/destination commits, then calls CodeCommit `PostComment` through the shared comment use case
+  6. `ccpr-mcp` returns the same `{commentId, pullRequestId, authorArn, creationDate}` object as `ccpr comment --format json`
+- Success:
+  - The comment is posted to the PR and Claude Code receives the resulting comment metadata
+- Failure:
+  - Missing `body`, or missing both `url` and (`repo` + `prId`) → tool call returns a validation error
+  - Missing region, invalid AWS credentials, PR metadata fetch failure, or `PostComment` failure → tool call returns the same guidance as the CLI path
+- Note:
+  - This is the first write-side MCP tool. Each successful call produces a real comment in CodeCommit; the tool description and README must make this explicit so the MCP host's per-call approval gate is meaningful.
+  - `--body-file` and stdin (`-`) input forms remain CLI-only — MCP callers pass the comment body as a string argument.

--- a/internal/app/comment.go
+++ b/internal/app/comment.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hidetzu/ccpr/internal/config"
+	"github.com/hidetzu/ccpr/internal/parser"
+)
+
+// PostCommentOptions contains inputs shared by the CLI and MCP comment paths.
+type PostCommentOptions struct {
+	URL     string
+	Repo    string
+	PRId    string
+	Body    string
+	Region  string
+	Profile string
+	Config  string
+}
+
+// PostedComment is the structured result of posting a comment, returned to
+// both the CLI (for JSON formatting) and the MCP tool. Field names match the
+// existing `ccpr comment --format json` schema.
+type PostedComment struct {
+	CommentID     string `json:"commentId"`
+	PullRequestID string `json:"pullRequestId"`
+	AuthorARN     string `json:"authorArn"`
+	CreationDate  string `json:"creationDate"`
+}
+
+// PostComment posts a comment to a CodeCommit pull request and returns the
+// resulting metadata. AWS-side failures are wrapped in *SystemError so callers
+// can distinguish them from user input errors.
+func PostComment(
+	ctx context.Context,
+	opts PostCommentOptions,
+	newClient CodeCommitClientFactory,
+) (PostedComment, error) {
+	if opts.Body == "" {
+		return PostedComment{}, fmt.Errorf("comment body is required")
+	}
+
+	var region, repo, prID string
+	if opts.URL != "" {
+		result, err := parser.Parse(opts.URL)
+		if err != nil {
+			return PostedComment{}, fmt.Errorf("invalid PR URL: %w", err)
+		}
+		region = result.Region
+		repo = result.Repository
+		prID = result.PRId
+	} else if opts.Repo != "" && opts.PRId != "" {
+		repo = opts.Repo
+		prID = opts.PRId
+	} else {
+		return PostedComment{}, fmt.Errorf("provide a PR URL or repo and prId")
+	}
+
+	cfg, _, err := config.Load(opts.Config)
+	if err != nil {
+		return PostedComment{}, fmt.Errorf("config: %w", err)
+	}
+
+	if region == "" {
+		region = cfg.ResolveRegion(opts.Region)
+	}
+	if region == "" {
+		return PostedComment{}, fmt.Errorf("region is required: use region option, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+	}
+
+	profile := cfg.ResolveProfile(opts.Profile)
+
+	cc, err := newClient(ctx, region, profile)
+	if err != nil {
+		return PostedComment{}, newSystemError("creating CodeCommit client: %w", err)
+	}
+
+	metadata, err := cc.GetPRMetadata(ctx, repo, prID)
+	if err != nil {
+		return PostedComment{}, newSystemError("fetching PR metadata: %w", err)
+	}
+
+	result, err := cc.PostComment(ctx, repo, prID, metadata.DestinationCommit, metadata.SourceCommit, opts.Body)
+	if err != nil {
+		return PostedComment{}, newSystemError("posting comment: %w", err)
+	}
+
+	return PostedComment{
+		CommentID:     result.CommentID,
+		PullRequestID: prID,
+		AuthorARN:     result.AuthorARN,
+		CreationDate:  result.CreationDate.Format("2006-01-02T15:04:05Z07:00"),
+	}, nil
+}

--- a/internal/app/comment_test.go
+++ b/internal/app/comment_test.go
@@ -1,0 +1,171 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hidetzu/ccpr/internal/codecommit"
+)
+
+type fakeCommentClient struct {
+	metadata          codecommit.PRMetadata
+	postResult        codecommit.PostCommentResult
+	postErr           error
+	gotMetadataRepo   string
+	gotMetadataPRID   string
+	gotPostRepo       string
+	gotPostPRID       string
+	gotPostBefore     string
+	gotPostAfter      string
+	gotPostBody       string
+}
+
+func (f *fakeCommentClient) GetPRMetadata(_ context.Context, repo, prID string) (codecommit.PRMetadata, error) {
+	f.gotMetadataRepo = repo
+	f.gotMetadataPRID = prID
+	return f.metadata, nil
+}
+
+func (f *fakeCommentClient) GetPRComments(context.Context, string, string, string, string) ([]codecommit.Comment, error) {
+	return nil, nil
+}
+
+func (f *fakeCommentClient) ListPRs(context.Context, string, string) ([]codecommit.PRSummary, error) {
+	return nil, nil
+}
+
+func (f *fakeCommentClient) PostComment(_ context.Context, repo, prID, before, after, body string) (codecommit.PostCommentResult, error) {
+	f.gotPostRepo = repo
+	f.gotPostPRID = prID
+	f.gotPostBefore = before
+	f.gotPostAfter = after
+	f.gotPostBody = body
+	return f.postResult, f.postErr
+}
+
+func (f *fakeCommentClient) CreatePR(context.Context, string, string, string, string, string) (codecommit.CreatePRResult, error) {
+	return codecommit.CreatePRResult{}, nil
+}
+
+func TestPostCommentRequiresBody(t *testing.T) {
+	_, err := PostComment(context.Background(), PostCommentOptions{Repo: "r", PRId: "1"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "body is required") {
+		t.Fatalf("error = %v, want body-required", err)
+	}
+}
+
+func TestPostCommentRequiresURLOrRepoAndPRId(t *testing.T) {
+	_, err := PostComment(context.Background(), PostCommentOptions{Body: "hi"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "URL or repo and prId") {
+		t.Fatalf("error = %v, want URL/repo guidance", err)
+	}
+}
+
+func TestPostCommentRejectsInvalidURL(t *testing.T) {
+	_, err := PostComment(context.Background(), PostCommentOptions{Body: "hi", URL: "not-a-url"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid PR URL") {
+		t.Fatalf("error = %v, want invalid URL", err)
+	}
+}
+
+func TestPostCommentURLDrivesRegionAndBuildsResult(t *testing.T) {
+	configPath := writeListConfig(t, "region: us-east-1\n")
+	created := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	cc := &fakeCommentClient{
+		metadata: codecommit.PRMetadata{
+			SourceCommit:      "src-commit",
+			DestinationCommit: "dst-commit",
+		},
+		postResult: codecommit.PostCommentResult{
+			CommentID:    "c-1",
+			AuthorARN:    "arn:aws:iam::123456789012:user/example",
+			CreationDate: created,
+		},
+	}
+
+	gotRegion := ""
+	got, err := PostComment(context.Background(), PostCommentOptions{
+		URL:    "https://ap-northeast-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/pull-requests/42",
+		Body:   "looks good",
+		Config: configPath,
+	}, func(_ context.Context, region, _ string) (codecommit.Client, error) {
+		gotRegion = region
+		return cc, nil
+	})
+	if err != nil {
+		t.Fatalf("PostComment returned error: %v", err)
+	}
+	if gotRegion != "ap-northeast-1" {
+		t.Fatalf("region = %q, want ap-northeast-1 (URL wins over config)", gotRegion)
+	}
+	if cc.gotMetadataRepo != "my-repo" || cc.gotMetadataPRID != "42" {
+		t.Fatalf("GetPRMetadata called with repo=%q prID=%q", cc.gotMetadataRepo, cc.gotMetadataPRID)
+	}
+	if cc.gotPostBefore != "dst-commit" || cc.gotPostAfter != "src-commit" {
+		t.Fatalf("PostComment called with before=%q after=%q", cc.gotPostBefore, cc.gotPostAfter)
+	}
+	if cc.gotPostBody != "looks good" {
+		t.Fatalf("PostComment body = %q", cc.gotPostBody)
+	}
+	if got.CommentID != "c-1" || got.PullRequestID != "42" {
+		t.Fatalf("result = %+v", got)
+	}
+	if got.CreationDate != "2026-05-04T10:00:00Z" {
+		t.Fatalf("CreationDate = %q", got.CreationDate)
+	}
+}
+
+func TestPostCommentRepoPRIdUsesConfigRegion(t *testing.T) {
+	configPath := writeListConfig(t, "region: ap-northeast-1\n")
+	cc := &fakeCommentClient{
+		metadata:   codecommit.PRMetadata{SourceCommit: "s", DestinationCommit: "d"},
+		postResult: codecommit.PostCommentResult{CommentID: "c-1", CreationDate: time.Now()},
+	}
+
+	gotRegion := ""
+	_, err := PostComment(context.Background(), PostCommentOptions{
+		Repo:   "my-repo",
+		PRId:   "42",
+		Body:   "hi",
+		Config: configPath,
+	}, func(_ context.Context, region, _ string) (codecommit.Client, error) {
+		gotRegion = region
+		return cc, nil
+	})
+	if err != nil {
+		t.Fatalf("PostComment returned error: %v", err)
+	}
+	if gotRegion != "ap-northeast-1" {
+		t.Fatalf("region = %q, want ap-northeast-1 from config", gotRegion)
+	}
+}
+
+func TestPostCommentWrapsAWSFailuresAsSystemError(t *testing.T) {
+	configPath := writeListConfig(t, "region: ap-northeast-1\n")
+	cc := &fakeCommentClient{
+		metadata: codecommit.PRMetadata{SourceCommit: "s", DestinationCommit: "d"},
+		postErr:  errors.New("boom"),
+	}
+
+	_, err := PostComment(context.Background(), PostCommentOptions{
+		Repo:   "my-repo",
+		PRId:   "42",
+		Body:   "hi",
+		Config: configPath,
+	}, func(context.Context, string, string) (codecommit.Client, error) {
+		return cc, nil
+	})
+	if err == nil {
+		t.Fatal("PostComment returned nil error")
+	}
+	var sysErr *SystemError
+	if !errors.As(err, &sysErr) {
+		t.Fatalf("error = %T %v, want *SystemError", err, err)
+	}
+	if !strings.Contains(err.Error(), "posting comment") {
+		t.Fatalf("error message = %q, want posting-comment context", err.Error())
+	}
+}

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -1,0 +1,16 @@
+package app
+
+import "fmt"
+
+// SystemError marks an error as system-level (AWS, Git) so CLI callers can
+// route it to a non-user exit code. Detect via errors.As.
+type SystemError struct {
+	err error
+}
+
+func (e *SystemError) Error() string { return e.err.Error() }
+func (e *SystemError) Unwrap() error { return e.err }
+
+func newSystemError(format string, a ...any) error {
+	return &SystemError{err: fmt.Errorf(format, a...)}
+}


### PR DESCRIPTION
## Summary

- Expose `ccpr comment --format json` over MCP as a new `ccpr_comment` tool, served by the existing `ccpr-mcp` binary alongside `ccpr_list` and `ccpr_review`. This is the first **write-side** MCP tool: each successful call posts a real comment to CodeCommit, so the tool description and README explicitly call this out for the MCP host's per-call approval gate.
- Extract the comment pipeline into `internal/app/comment.go` so the CLI and MCP paths share input validation, AWS profile/region resolution, PR-metadata fetching (for the `before/after` commits), and the `PostComment` call. The existing `ccpr comment --format json` schema is preserved unchanged.
- Introduce `app.SystemError` so the shared use case can mark AWS-side failures and the CLI's `exitCode` router keeps exiting `2` on those, preserving pre-migration CLI behavior. `--body-file` and stdin (`-`) input forms remain CLI-only.
- Update `docs/use-cases.md` (UC-13), `docs/requirements.md` (FR-18), `docs/spec.md`, `docs/json-schema.md`, and the READMEs. The "no write-side MCP tools" constraint is removed; `create`/`open`/`doctor` remain out of scope.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change
- [x] Documentation (`docs:`)
- [x] Refactor / chore (`refactor:` / `chore:`)
- [x] Test (`test:`)

(Primary type: `feat:`. Refactor extracts the comment pipeline; docs and tests are part of the same change.)

## Test plan

- [x] `make build` / `make build-mcp` / `make test` / `make vet` / `make lint` all pass
- [x] `go test ./internal/app/...` covers `PostComment` happy path, validation errors, region precedence, and `SystemError` wrapping for AWS failures
- [x] CLI golden tests under `cmd/ccpr/testdata/` continue to pass (no JSON output regression)
- [x] Manual JSON-RPC smoke: `initialize` + `tools/list` returns all three tools (`ccpr_list`, `ccpr_review`, `ccpr_comment`) with `outputSchema.type == "object"`
- [ ] End-to-end smoke via Claude Code MCP registration against a real CodeCommit PR

## Spec-driven checklist

- [x] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code
- [x] No breaking changes to JSON output (see `docs/versioning.md`); the CLI `ccpr comment --format json` payload is unchanged. The MCP tool returns the same object directly (no wrapper needed because it is already an object).

## Related issues

Closes #60.