### PR TITLE
fix: restore CLI flag wording in shared validation errors

### DIFF
--- a/cmd/ccpr/comment.go
+++ b/cmd/ccpr/comment.go
@@ -61,7 +61,7 @@ func runComment(args []string) error {
 		Config:  flagConfig,
 	}, newCodeCommitClient)
 	if err != nil {
-		return err
+		return translateAppError(err)
 	}
 
 	if flagFormat == "json" {

--- a/cmd/ccpr/create.go
+++ b/cmd/ccpr/create.go
@@ -83,7 +83,7 @@ func runCreate(args []string) error {
 		Config:            flagConfig,
 	}, newCodeCommitClient)
 	if err != nil {
-		return err
+		return translateAppError(err)
 	}
 
 	if flagFormat == "json" {

--- a/cmd/ccpr/errors.go
+++ b/cmd/ccpr/errors.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hidetzu/ccpr/internal/app"
+)
+
+// translateAppError converts surface-neutral validation errors from
+// internal/app into CLI flag-aware messages. AWS/system failures and other
+// errors pass through unchanged.
+func translateAppError(err error) error {
+	switch {
+	case errors.Is(err, app.ErrMissingPRRef):
+		return fmt.Errorf("provide a PR URL or --repo and --pr-id flags")
+	case errors.Is(err, app.ErrMissingRegion):
+		return fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+	}
+	return err
+}

--- a/cmd/ccpr/errors_test.go
+++ b/cmd/ccpr/errors_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hidetzu/ccpr/internal/app"
+)
+
+func TestTranslateAppErrorMissingPRRef(t *testing.T) {
+	got := translateAppError(app.ErrMissingPRRef)
+	want := "provide a PR URL or --repo and --pr-id flags"
+	if got == nil || got.Error() != want {
+		t.Fatalf("got %v, want %q", got, want)
+	}
+}
+
+func TestTranslateAppErrorMissingRegion(t *testing.T) {
+	got := translateAppError(app.ErrMissingRegion)
+	want := "region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env"
+	if got == nil || got.Error() != want {
+		t.Fatalf("got %v, want %q", got, want)
+	}
+}
+
+func TestTranslateAppErrorPassesThrough(t *testing.T) {
+	other := errors.New("something else")
+	got := translateAppError(other)
+	if got != other {
+		t.Fatalf("got %v, want passthrough", got)
+	}
+}
+
+func TestTranslateAppErrorPassesThroughNil(t *testing.T) {
+	if got := translateAppError(nil); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}

--- a/cmd/ccpr/list.go
+++ b/cmd/ccpr/list.go
@@ -54,7 +54,7 @@ func runList(args []string) error {
 		Region:  flagRegion,
 	}, newCodeCommitClient)
 	if err != nil {
-		return err
+		return translateAppError(err)
 	}
 
 	if flagFormat == "json" {

--- a/cmd/ccpr/review.go
+++ b/cmd/ccpr/review.go
@@ -50,7 +50,7 @@ func runReview(args []string) error {
 		Config:  flagConfig,
 	}, newCodeCommitClient, defaultDiffGenerator)
 	if err != nil {
-		return err
+		return translateAppError(err)
 	}
 
 	switch flagFormat {

--- a/internal/app/comment.go
+++ b/internal/app/comment.go
@@ -54,7 +54,7 @@ func PostComment(
 		repo = opts.Repo
 		prID = opts.PRId
 	} else {
-		return PostedComment{}, fmt.Errorf("provide a PR URL or repo and prId")
+		return PostedComment{}, ErrMissingPRRef
 	}
 
 	cfg, _, err := config.Load(opts.Config)
@@ -66,7 +66,7 @@ func PostComment(
 		region = cfg.ResolveRegion(opts.Region)
 	}
 	if region == "" {
-		return PostedComment{}, fmt.Errorf("region is required: use region option, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+		return PostedComment{}, ErrMissingRegion
 	}
 
 	profile := cfg.ResolveProfile(opts.Profile)

--- a/internal/app/comment_test.go
+++ b/internal/app/comment_test.go
@@ -59,8 +59,8 @@ func TestPostCommentRequiresBody(t *testing.T) {
 
 func TestPostCommentRequiresURLOrRepoAndPRId(t *testing.T) {
 	_, err := PostComment(context.Background(), PostCommentOptions{Body: "hi"}, nil)
-	if err == nil || !strings.Contains(err.Error(), "URL or repo and prId") {
-		t.Fatalf("error = %v, want URL/repo guidance", err)
+	if !errors.Is(err, ErrMissingPRRef) {
+		t.Fatalf("error = %v, want ErrMissingPRRef", err)
 	}
 }
 

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -65,7 +65,7 @@ func CreatePullRequest(
 
 	region := cfg.ResolveRegion(opts.Region)
 	if region == "" {
-		return CreatedPullRequest{}, fmt.Errorf("region is required: use region option, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+		return CreatedPullRequest{}, ErrMissingRegion
 	}
 	profile := cfg.ResolveProfile(opts.Profile)
 

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -1,6 +1,9 @@
 package app
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // SystemError marks an error as system-level (AWS, Git) so CLI callers can
 // route it to a non-user exit code. Detect via errors.As.
@@ -14,3 +17,16 @@ func (e *SystemError) Unwrap() error { return e.err }
 func newSystemError(format string, a ...any) error {
 	return &SystemError{err: fmt.Errorf(format, a...)}
 }
+
+// Sentinel validation errors. CLI callers translate these to flag-aware
+// wording via errors.Is; the MCP server lets them surface as-is so MCP clients
+// see surface-neutral messages.
+var (
+	// ErrMissingPRRef is returned when a use case requires either a PR URL
+	// or a (repo + prId) pair and neither is provided.
+	ErrMissingPRRef = errors.New("provide a PR URL or repo and prId")
+
+	// ErrMissingRegion is returned when no AWS region can be resolved from
+	// the use-case input, the config file, or the standard AWS env variables.
+	ErrMissingRegion = errors.New("region is required: use region option, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+)

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -34,7 +34,7 @@ type ListPullRequest struct {
 // ListPullRequests returns pull request summaries for a repository.
 func ListPullRequests(ctx context.Context, opts ListPullRequestsOptions, newClient CodeCommitClientFactory) ([]ListPullRequest, error) {
 	if opts.Repo == "" {
-		return nil, fmt.Errorf("--repo is required for list command")
+		return nil, fmt.Errorf("repo is required")
 	}
 
 	status := opts.Status
@@ -55,7 +55,7 @@ func ListPullRequests(ctx context.Context, opts ListPullRequestsOptions, newClie
 	profile := cfg.ResolveProfile(opts.Profile)
 	region := cfg.ResolveRegion(opts.Region)
 	if region == "" {
-		return nil, fmt.Errorf("region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+		return nil, ErrMissingRegion
 	}
 
 	cc, err := newClient(ctx, region, profile)

--- a/internal/app/review.go
+++ b/internal/app/review.go
@@ -51,7 +51,7 @@ func GetReview(
 		repo = opts.Repo
 		prID = opts.PRId
 	} else {
-		return ReviewPayload{}, fmt.Errorf("provide a PR URL or repo and prId")
+		return ReviewPayload{}, ErrMissingPRRef
 	}
 
 	cfg, _, err := config.Load(opts.Config)
@@ -63,7 +63,7 @@ func GetReview(
 		region = cfg.ResolveRegion(opts.Region)
 	}
 	if region == "" {
-		return ReviewPayload{}, fmt.Errorf("region is required: use region option, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env")
+		return ReviewPayload{}, ErrMissingRegion
 	}
 
 	repoPath, err := cfg.ResolveRepoPath(repo)

--- a/internal/app/review_test.go
+++ b/internal/app/review_test.go
@@ -67,11 +67,8 @@ func (f *fakeDiffGen) GenerateDiff(repoPath, sourceBranch, destBranch string) (s
 
 func TestGetReviewRequiresURLOrRepoAndPRId(t *testing.T) {
 	_, err := GetReview(context.Background(), GetReviewOptions{}, nil, nil)
-	if err == nil {
-		t.Fatal("GetReview returned nil error")
-	}
-	if !strings.Contains(err.Error(), "URL or repo and prId") {
-		t.Fatalf("error = %q, want URL/repo guidance", err.Error())
+	if !errors.Is(err, ErrMissingPRRef) {
+		t.Fatalf("error = %v, want ErrMissingPRRef", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Introduce two sentinel errors in `internal/app` — `ErrMissingPRRef` (no PR URL or repo + prId) and `ErrMissingRegion` — and have the affected use cases (`list`, `review`, `comment`, `create`) return them instead of formatted strings.
- Add `cmd/ccpr/errors.go` with a `translateAppError` helper that converts those sentinels to the original CLI flag-aware messages (`provide a PR URL or --repo and --pr-id flags`, `region is required: use --region flag, ...`). Each CLI command wraps the use-case call so its returned errors pass through the translator.
- Clean up an additional inconsistency: `internal/app/list.go` previously returned the CLI-flavored `--repo is required for list command` even though the CLI pre-checks `--repo` itself. The use case now returns a neutral `repo is required`; the CLI's pre-check is unchanged so end-user wording is unaffected.
- Tests updated: `internal/app/{review,comment}_test.go` use `errors.Is` against the new sentinels for robustness, and `cmd/ccpr/errors_test.go` covers the translator (matched cases, passthrough, nil).

## Verification

CLI:

```text
$ ccpr review
error: provide a PR URL or --repo and --pr-id flags

$ ccpr list --repo my-repo --config <no-region>
error: region is required: use --region flag, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env
```

MCP (same condition, via JSON-RPC tools/call):

```text
"region is required: use region option, set region in config file, or set AWS_REGION/AWS_DEFAULT_REGION env"
```

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [ ] Documentation (`docs:`)
- [x] Refactor / chore (`refactor:` / `chore:`)
- [x] Test (`test:`)

## Test plan

- [x] `make build` / `make build-mcp` / `make test` / `make vet` / `make lint` all pass
- [x] CLI smoke confirms restored flag-aware wording for both `ErrMissingPRRef` and `ErrMissingRegion`
- [x] MCP smoke confirms generic wording is preserved for MCP callers

## Spec-driven checklist

- [x] `docs/use-cases.md`, `docs/requirements.md`, `docs/spec.md` updated before code (or N/A for non-feature changes) — N/A; spec already describes errors abstractly without pinning string content.
- [x] No breaking changes to JSON output (see `docs/versioning.md`); only CLI/MCP error message wording changes, no JSON payload schema changes.

## Related issues

Closes #63.