### PR TITLE
docs: declare permanent scope non-goals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,12 @@ MVP implemented:
 - Config initialization (`ccpr init`)
 - Environment validation (`ccpr doctor`)
 
-Out of scope (for now):
+Out of scope (permanent non-goals):
 
-- Line-level comments
-- TUI
-- Multi-provider support (GitHub/GitLab)
-- Complex approval workflows
+- Line-level review comments — `gh` CLI does not expose these either, and ccpr targets feature parity with `gh` for CodeCommit. PR-level comments via `ccpr comment` cover the intended workflow.
+- Multi-provider support (GitHub / GitLab) — ccpr exists specifically as a `gh`-style CLI for CodeCommit. GitHub already has `gh` and GitLab has `glab`; expanding ccpr to other providers contradicts its reason for existing.
+- TUI — ccpr's role is to emit machine-readable output (JSON / patch) for AI tools. An interactive TUI is a different product and is not aligned with this design.
+- Complex approval workflows (multi-reviewer rules, re-request flows, etc.) — out of step with the thin-CLI principle and not part of the `gh`-style baseline ccpr targets.
 
 ## Architecture Principles
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -307,3 +307,20 @@ Target format:
     "message": "description"
   }
 }
+
+---
+
+## Scope
+
+### Out of Scope (permanent non-goals)
+
+These items are deliberately not part of ccpr's roadmap. They conflict with the project's stated purpose ("a `gh`-style CLI for CodeCommit") and will not be reconsidered without a corresponding change to that purpose.
+
+- **Line-level review comments**: ccpr targets feature parity with the `gh` CLI for CodeCommit workflows. `gh` itself does not provide line-level review comments — it operates at the PR level (overall comment, approve, request-changes). PR-level commenting via `ccpr comment` (and `ccpr_comment` over MCP) covers the intended workflow, and adding line-level support would diverge from the `gh`-style UX ccpr is modeled after.
+- **Multi-provider support (GitHub / GitLab)**: ccpr exists specifically because CodeCommit lacks a `gh`-equivalent. GitHub already has `gh`; GitLab has `glab`. Expanding ccpr to other providers contradicts its reason for existing and dilutes the CodeCommit-specific design (URL parsing, AWS profile/region resolution, CodeCommit SDK calls).
+- **TUI**: ccpr's role is to emit machine-readable output (JSON / patch) so AI tools and shell pipelines can consume it. An interactive TUI is a different product surface and is not aligned with the "CLI should be thin and composable" architecture principle.
+- **Complex approval workflows**: multi-reviewer rules, re-request flows, codeowner-style policies, etc. are out of step with the thin-CLI principle and outside the `gh`-style baseline ccpr targets. Basic comment / approve / merge stays in scope as the underlying CodeCommit API supports it.
+
+### Out of Scope (for now)
+
+- Structured JSON error output (see NFR-03)


### PR DESCRIPTION
## Summary

- Reorganize the Out-of-scope list in `CLAUDE.md` and `docs/requirements.md` to distinguish **permanent non-goals** from genuinely deferred work.
- Promote four items to permanent non-goals because they conflict with ccpr's stated purpose (a `gh`-style CLI for CodeCommit), not because they are simply deferred:
  - Line-level review comments — `gh` itself does not expose these
  - Multi-provider support (GitHub / GitLab) — `gh` and `glab` already cover those
  - TUI — ccpr's role is machine-readable output for AI tools
  - Complex approval workflows — outside the thin-CLI / `gh`-style baseline
- Structured JSON error output (NFR-03) remains the only deferred item.

No code changes; documentation only.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [x] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:` / `chore:`)
- [ ] Test (`test:`)

## Test plan

- [x] `CLAUDE.md` Out-of-scope section reads cleanly and matches `docs/requirements.md`
- [x] `docs/requirements.md` `## Scope` section lists permanent non-goals with rationale and keeps NFR-03 under "for now"
- [x] `git diff main...HEAD` touches only `CLAUDE.md` and `docs/requirements.md`

## Spec-driven checklist

- [x] `docs/requirements.md` updated; `docs/use-cases.md` / `docs/spec.md` not affected by this scope-clarification (no behavior change)
- [x] No breaking changes to JSON output; no changes under `cmd/ccpr/testdata/`

## Related issues

N/A